### PR TITLE
Fix cmdlet parameter binding for PSObject-wrapped values and add a lab release gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,6 @@ src/Lithnet.ResourceManagement.Automation.Setup/LithnetRMA/
 src/Lithnet.ResourceManagement.Automation.Setup/output/
 src/Lithnet.ResourceManagement.Automation.Setup/*-cache/
 src/Lithnet.ResourceManagement.Automation.Setup/*-SetupFiles/
+
+# Staged module output produced by test/LithnetRMA.Tests/Build-TestModule.ps1
+test/LithnetRMA.Tests/.module/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -247,8 +247,10 @@ stages:
         azureSubscription: $(devAzureSubscription)
         agentMode: pool
         targetPoolName: $(testEnvironment)
-        # A cold start from deallocated regularly exceeds the template's
-        # 300-second default before the agent registers.
+        # A normal cold start registers the agent in under two minutes, but
+        # boot-time outliers (Windows Update finalization, slow host
+        # allocation) can take far longer; the headroom costs nothing because
+        # the wait exits as soon as the agent is online.
         timeoutSeconds: 900
 
 # ── Test the signed module against the lab MIM service (release gate) ────

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,6 +88,10 @@ variables:
 
 name: $(build.version.major).$(build.version.minor).$(build.version.revision)
 trigger: none
+# PR validation is disabled deliberately: the test stage owns the single-agent
+# UnitTest1 lab pool, and a PR-triggered run would race whatever gate run is
+# already using it.
+pr: none
 
 resources:
   repositories:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -247,11 +247,6 @@ stages:
         azureSubscription: $(devAzureSubscription)
         agentMode: pool
         targetPoolName: $(testEnvironment)
-        # A normal cold start registers the agent in under two minutes, but
-        # boot-time outliers (Windows Update finalization, slow host
-        # allocation) can take far longer; the headroom costs nothing because
-        # the wait exits as soon as the agent is online.
-        timeoutSeconds: 900
 
 # ── Test the signed module against the lab MIM service (release gate) ────
 # The variable group supplies the second-user credential for the approval

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,8 @@
 # Builds the PowerShell module, signs the assemblies, manifest, and package
 # with the Lithnet EV code-signing certificate, builds and signs the MSI
 # installer with Advanced Installer, publishes to the internal Azure
-# Artifacts feed, and (after approval) creates a GitHub release with the
+# Artifacts feed, runs the Pester suite against the lab MIM service as a
+# release gate, and (after approval) creates a GitHub release with the
 # installer and module package, then publishes to the public PSGallery.
 #
 # Signing split:
@@ -12,6 +13,16 @@
 #     they are packaged, so both the .nupkg and the MSI embed signed files.
 #   * build-advanced-installer-package.yaml (sign: true) signs the MSI
 #     itself during the Advanced Installer build.
+#
+# Test gate:
+#   * The UnitTest1 lab VM (u1w2025x64-ad) is deallocated when idle, so the
+#     pipeline starts it by tag before testing and deallocates it afterwards
+#     using the shared release-tools VM lifecycle templates.
+#   * The test stage runs on the self-hosted UnitTest1 pool, which has line
+#     of sight to the lab MIM service (fimsvc). It tests the exact signed
+#     module artifact produced by the build stage, on both Windows
+#     PowerShell 5.1 and PowerShell 7. Publishing cannot proceed unless
+#     every test passes.
 #
 # All signing and publishing is delegated to the shared release-tools repo.
 # No signing-vault or feed details live in this file.
@@ -36,6 +47,18 @@ variables:
 
   - name: azureSubscription
     value: 'ProductionServices'
+
+  # The lab test environment: VMs tagged environment=testEnvironment in
+  # testResourceGroup back the agent pool of the same name. They are
+  # deallocated when idle; the pipeline starts and stops them around the
+  # test stage. devAzureSubscription is the service connection with rights
+  # on that resource group.
+  - name: testEnvironment
+    value: 'UnitTest1'
+  - name: testResourceGroup
+    value: 'rg-ams-testhosts'
+  - name: devAzureSubscription
+    value: 'DevEnvironment'
 
   - name: tfmCore
     value: 'net8.0'
@@ -215,10 +238,120 @@ stages:
             publishLocation: 'pipeline'
             artifact: installer
 
+# ── Start the lab test VM (deallocated when idle) ────────────────────────
+- stage: start_test_vms
+  displayName: Start lab test VMs
+  dependsOn: build
+  jobs:
+    - template: templates/azure-vm-start.yaml@release_tools
+      parameters:
+        jobName: start_test_vms
+        deployEnvironment: $(testEnvironment)
+        distroType: win
+        resourceGroup: $(testResourceGroup)
+        azureSubscription: $(devAzureSubscription)
+        agentMode: pool
+        targetPoolName: $(testEnvironment)
+
+# ── Test the signed module against the lab MIM service (release gate) ────
+# The variable group supplies the second-user credential for the approval
+# tests (they skip without it, and approvals are the most complex flow, so
+# they must run on every gate) and the proxy SPN for RemoteProxy cases.
+#
+# The full suite runs once per transport so behavioural differences between
+# them are caught: on PowerShell 7 under LocalProxy, RemoteProxy, and
+# DirectNetTcp; on Windows PowerShell 5.1 under DirectWsHttp, the primary
+# transport for .NET Framework hosts (message-security WSHttp only works
+# there). The other transports also work on 5.1 and are exercised on it by
+# the approval tests inside the run; the client library's own pipeline
+# covers the full runtime x transport matrix via its net472/net48 test
+# targets.
+- stage: test
+  displayName: Pester suite against lab MIM
+  dependsOn: start_test_vms
+  variables:
+    - group: MIM lab test credentials
+  jobs:
+    - job: pester_job
+      displayName: Run Pester suite on both PowerShell editions
+      pool: UnitTest1
+      steps:
+        - checkout: self
+          path: s/resourcemanagement-powershell
+
+        - download: current
+          artifact: LithnetRMA
+
+        - powershell: |
+            if (-not (Get-Module Pester -ListAvailable | Where-Object { $_.Version -ge [version]'5.7.1' })) {
+                Install-Module Pester -RequiredVersion 5.7.1 -Scope CurrentUser -Force -SkipPublisherCheck
+            }
+            Import-Module Pester -MinimumVersion 5.7.1
+            $config = New-PesterConfiguration
+            $config.Run.Path = '$(Build.SourcesDirectory)/resourcemanagement-powershell/test/LithnetRMA.Tests'
+            $config.Run.Exit = $true
+            $config.Output.Verbosity = 'Detailed'
+            $config.TestResult.Enabled = $true
+            $config.TestResult.OutputFormat = 'NUnitXml'
+            $config.TestResult.OutputPath = '$(Common.TestResultsDirectory)/pester-desktop-DirectWsHttp.xml'
+            Invoke-Pester -Configuration $config
+          displayName: Pester (Windows PowerShell 5.1, DirectWsHttp)
+          condition: succeededOrFailed()
+          env:
+            LITHNETRMA_MODULE_PATH: $(Pipeline.Workspace)/LithnetRMA/LithnetRMA.psd1
+            LITHNETRMA_TEST_MODE: DirectWsHttp
+            LITHNETRMA_TEST_APPROVAL_PASSWORD: $(LITHNETRMA_TEST_APPROVAL_PASSWORD)
+
+        - ${{ each mode in split('LocalProxy,RemoteProxy,DirectNetTcp', ',') }}:
+          - pwsh: |
+              if (-not (Get-Module Pester -ListAvailable | Where-Object { $_.Version -ge [version]'5.7.1' })) {
+                  Install-Module Pester -RequiredVersion 5.7.1 -Scope CurrentUser -Force -SkipPublisherCheck
+              }
+              Import-Module Pester -MinimumVersion 5.7.1
+              $config = New-PesterConfiguration
+              $config.Run.Path = '$(Build.SourcesDirectory)/resourcemanagement-powershell/test/LithnetRMA.Tests'
+              $config.Run.Exit = $true
+              $config.Output.Verbosity = 'Detailed'
+              $config.TestResult.Enabled = $true
+              $config.TestResult.OutputFormat = 'NUnitXml'
+              $config.TestResult.OutputPath = '$(Common.TestResultsDirectory)/pester-coreclr-${{ mode }}.xml'
+              Invoke-Pester -Configuration $config
+            displayName: Pester (PowerShell 7, ${{ mode }})
+            condition: succeededOrFailed()
+            env:
+              LITHNETRMA_MODULE_PATH: $(Pipeline.Workspace)/LithnetRMA/LithnetRMA.psd1
+              LITHNETRMA_TEST_MODE: ${{ mode }}
+              LITHNETRMA_TEST_APPROVAL_PASSWORD: $(LITHNETRMA_TEST_APPROVAL_PASSWORD)
+
+        - task: PublishTestResults@2
+          displayName: Publish Pester results
+          condition: succeededOrFailed()
+          inputs:
+            testResultsFormat: 'NUnit'
+            testResultsFiles: 'pester-*.xml'
+            searchFolder: '$(Common.TestResultsDirectory)'
+            mergeTestResults: true
+            failTaskOnFailedTests: true
+            testRunTitle: 'LithnetRMA Pester suite'
+
+# ── Deallocate the lab test VM ────────────────────────────────────────────
+- stage: stop_test_vms
+  displayName: Stop lab test VMs
+  dependsOn: test
+  condition: always()
+  jobs:
+    - template: templates/azure-vm-stop.yaml@release_tools
+      parameters:
+        jobName: stop_test_vms
+        deployEnvironment: $(testEnvironment)
+        distroType: win
+        resourceGroup: $(testResourceGroup)
+        azureSubscription: $(devAzureSubscription)
+
 # ── Publish GitHub release (requires approval) ───────────────────────────
 - stage: publish_github
   displayName: Publish GitHub release
-  dependsOn: build
+  dependsOn: test
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
   jobs:
     - deployment: publish_github_job

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -291,7 +291,7 @@ stages:
             }
             Import-Module Pester -MinimumVersion 5.7.1
             $config = New-PesterConfiguration
-            $config.Run.Path = '$(Build.SourcesDirectory)/resourcemanagement-powershell/test/LithnetRMA.Tests'
+            $config.Run.Path = '$(Pipeline.Workspace)/s/resourcemanagement-powershell/test/LithnetRMA.Tests'
             $config.Run.Exit = $true
             $config.Output.Verbosity = 'Detailed'
             $config.TestResult.Enabled = $true
@@ -312,7 +312,7 @@ stages:
               }
               Import-Module Pester -MinimumVersion 5.7.1
               $config = New-PesterConfiguration
-              $config.Run.Path = '$(Build.SourcesDirectory)/resourcemanagement-powershell/test/LithnetRMA.Tests'
+              $config.Run.Path = '$(Pipeline.Workspace)/s/resourcemanagement-powershell/test/LithnetRMA.Tests'
               $config.Run.Exit = $true
               $config.Output.Verbosity = 'Detailed'
               $config.TestResult.Enabled = $true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -275,6 +275,9 @@ stages:
     - job: pester_job
       displayName: Run Pester suite on both PowerShell editions
       pool: UnitTest1
+      # Self-hosted jobs have no timeout by default; a hang would hold the
+      # single-agent pool indefinitely.
+      timeoutInMinutes: 120
       steps:
         - checkout: self
           path: s/resourcemanagement-powershell
@@ -283,6 +286,11 @@ stages:
           artifact: LithnetRMA
 
         - powershell: |
+            # Windows PowerShell cannot Install-Module non-interactively until the
+            # NuGet package provider has been bootstrapped for the account.
+            if (-not (Get-PackageProvider -Name NuGet -ListAvailable -ErrorAction SilentlyContinue)) {
+                Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -Scope CurrentUser | Out-Null
+            }
             if (-not (Get-Module Pester -ListAvailable | Where-Object { $_.Version -ge [version]'5.7.1' })) {
                 Install-Module Pester -RequiredVersion 5.7.1 -Scope CurrentUser -Force -SkipPublisherCheck
             }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,10 +3,12 @@
 # =========================================================================
 # Builds the PowerShell module, signs the assemblies, manifest, and package
 # with the Lithnet EV code-signing certificate, builds and signs the MSI
-# installer with Advanced Installer, publishes to the internal Azure
-# Artifacts feed, runs the Pester suite against the lab MIM service as a
-# release gate, and (after approval) creates a GitHub release with the
-# installer and module package, then publishes to the public PSGallery.
+# installer with Advanced Installer, and runs the Pester suite against the
+# lab MIM service as a release gate. Publishing is gated on that test stage:
+# the internal Azure Artifacts feed only ever receives packages that have
+# passed the full suite, and (after approval) a GitHub release is created
+# with the installer and module package, then published to the public
+# PSGallery.
 #
 # Signing split:
 #   * codesign.yaml signs the module assembly, manifest, and loader before
@@ -186,13 +188,6 @@ stages:
             environment: 'prod'
             azureSubscription: '$(azureSubscription)'
 
-        # Publish to the internal Azure Artifacts feed.
-        - template: templates/publish-nuget.yaml@release_tools
-          parameters:
-            nugetPackagePath: '$(nupkgDir)/*.nupkg'
-            publishInternal: true
-            publishExternal: false
-
         # Stamp the installer project with the pipeline version and a fresh
         # ProductCode (required for MSI major upgrades between releases).
         - pwsh: |
@@ -252,6 +247,9 @@ stages:
         azureSubscription: $(devAzureSubscription)
         agentMode: pool
         targetPoolName: $(testEnvironment)
+        # A cold start from deallocated regularly exceeds the template's
+        # 300-second default before the agent registers.
+        timeoutSeconds: 900
 
 # ── Test the signed module against the lab MIM service (release gate) ────
 # The variable group supplies the second-user credential for the approval
@@ -348,10 +346,34 @@ stages:
         resourceGroup: $(testResourceGroup)
         azureSubscription: $(devAzureSubscription)
 
+# ── Publish the tested package to the internal feed ──────────────────────
+# Runs only after the test gate passes, so the internal feed never holds an
+# untested package.
+- stage: publish_internal
+  displayName: Publish to internal feed
+  dependsOn: test
+  condition: succeeded()
+  jobs:
+    - job: publish_internal_job
+      displayName: Publish module package to internal feed
+      steps:
+        - checkout: none
+
+        - download: current
+          artifact: nupkg
+
+        - template: templates/publish-nuget.yaml@release_tools
+          parameters:
+            nugetPackagePath: '$(Pipeline.Workspace)/nupkg/*.nupkg'
+            publishInternal: true
+            publishExternal: false
+
 # ── Publish GitHub release (requires approval) ───────────────────────────
+# Sequenced after the internal publish so the public release can never carry
+# a package the internal feed does not.
 - stage: publish_github
   displayName: Publish GitHub release
-  dependsOn: test
+  dependsOn: publish_internal
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
   jobs:
     - deployment: publish_github_job

--- a/src/Lithnet.ResourceManagement.Automation/Lithnet.ResourceManagement.Automation.csproj
+++ b/src/Lithnet.ResourceManagement.Automation/Lithnet.ResourceManagement.Automation.csproj
@@ -20,7 +20,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Lithnet.ResourceManagement.Client" Version="2.0.22" />
+		<PackageReference Include="Lithnet.ResourceManagement.Client" Version="2.0.30" />
 		<PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
 			<PrivateAssets>all</PrivateAssets>

--- a/src/Lithnet.ResourceManagement.Automation/NewResourceUpdateTemplate.cs
+++ b/src/Lithnet.ResourceManagement.Automation/NewResourceUpdateTemplate.cs
@@ -15,6 +15,7 @@ namespace Lithnet.ResourceManagement.Automation
         public string ObjectType { get; set; }
 
         [Parameter(Mandatory = true, Position = 2)]
+        [UnwrapPSObject]
         public object ID { get; set; }
 
         protected override void ProcessRecord()

--- a/src/Lithnet.ResourceManagement.Automation/NewXpathExpression.cs
+++ b/src/Lithnet.ResourceManagement.Automation/NewXpathExpression.cs
@@ -22,7 +22,7 @@ namespace Lithnet.ResourceManagement.Automation
         //}
 
         [Parameter(Mandatory = false, Position = 2, ValueFromPipeline = true)]
-        public object QueryObject { get; set; }
+        public IXPathQueryObject QueryObject { get; set; }
 
         [Parameter(Mandatory = false, Position = 3)]
         public string DereferenceAttribute { get; set; }
@@ -34,11 +34,11 @@ namespace Lithnet.ResourceManagement.Automation
         {
             if (this.DereferenceAttribute == null)
             {
-                this.WriteObject(new XPathExpression(this.ObjectType, (IXPathQueryObject)this.QueryObject, this.WrapFilterXml.IsPresent));
+                this.WriteObject(new XPathExpression(this.ObjectType, this.QueryObject, this.WrapFilterXml.IsPresent));
             }
             else
             {
-                this.WriteObject(new XPathDereferencedExpression(this.ObjectType, this.DereferenceAttribute, (IXPathQueryObject)this.QueryObject, this.WrapFilterXml.IsPresent));
+                this.WriteObject(new XPathDereferencedExpression(this.ObjectType, this.DereferenceAttribute, this.QueryObject, this.WrapFilterXml.IsPresent));
             }
         }
 

--- a/src/Lithnet.ResourceManagement.Automation/NewXpathQueryGroup.cs
+++ b/src/Lithnet.ResourceManagement.Automation/NewXpathQueryGroup.cs
@@ -15,11 +15,11 @@ namespace Lithnet.ResourceManagement.Automation
         public GroupOperator Operator { get; set; }
 
         [Parameter(Mandatory = false, Position = 2, ValueFromPipeline = true)]
-        public object[] Queries { get; set; }
+        public IXPathQueryObject[] Queries { get; set; }
 
         protected override void ProcessRecord()
         {
-            this.WriteObject(new XPathQueryGroup((Client.GroupOperator)this.Operator, (IXPathQueryObject[])this.Queries));
+            this.WriteObject(new XPathQueryGroup((Client.GroupOperator)this.Operator, this.Queries));
         }
     }
 }

--- a/src/Lithnet.ResourceManagement.Automation/RemoveResource.cs
+++ b/src/Lithnet.ResourceManagement.Automation/RemoveResource.cs
@@ -12,6 +12,7 @@ namespace Lithnet.ResourceManagement.Automation
     public class RemoveResource : Cmdlet
     {
         [Parameter(Mandatory = true, Position = 1, ParameterSetName = "ID")]
+        [UnwrapPSObject]
         public object[] ID { get; set; }
 
         [Parameter(Mandatory = true, Position = 1, ValueFromPipeline = true, ParameterSetName = "ResourceObject")]

--- a/src/Lithnet.ResourceManagement.Automation/UnwrapPSObjectAttribute.cs
+++ b/src/Lithnet.ResourceManagement.Automation/UnwrapPSObjectAttribute.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections;
+using System.Management.Automation;
+
+namespace Lithnet.ResourceManagement.Automation
+{
+    /// <summary>
+    /// Unwraps a PSObject wrapper from a parameter value (and, for a collection parameter, from each
+    /// element) before it is bound. PowerShell wraps a value passed to a parameter declared as
+    /// <see cref="object"/> in a <see cref="PSObject"/>, because there is no target type for the
+    /// binder to coerce to. A cmdlet that accepts a genuinely polymorphic value (for example an
+    /// identifier that may be a Guid, a string or a UniqueIdentifier) must therefore unwrap before it
+    /// type-tests the value, or the tests silently miss and the value is dropped. Parameters that have
+    /// a single concrete type do not need this - declare the real type instead.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class UnwrapPSObjectAttribute : ArgumentTransformationAttribute
+    {
+        public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
+        {
+            if (inputData == null)
+            {
+                return null;
+            }
+
+            object value = Unwrap(inputData);
+
+            if (value is IList list && !(value is byte[]) && !(value is string))
+            {
+                object[] result = new object[list.Count];
+
+                for (int i = 0; i < list.Count; i++)
+                {
+                    result[i] = Unwrap(list[i]);
+                }
+
+                return result;
+            }
+
+            return value;
+        }
+
+        private static object Unwrap(object value)
+        {
+            PSObject psObject = value as PSObject;
+
+            if (psObject != null)
+            {
+                return psObject.BaseObject;
+            }
+
+            return value;
+        }
+    }
+}

--- a/test/LithnetRMA.Tests/Approval.Tests.ps1
+++ b/test/LithnetRMA.Tests/Approval.Tests.ps1
@@ -87,6 +87,22 @@ BeforeAll {
         return $false
     }
 
+    # Same contract for the scenario preconditions (resolvable approver/requestor Persons, an
+    # approval workflow bound in the lab): on the gate these are lab regressions and must fail
+    # loudly, because approvals are mandatory gate coverage; locally they skip so the suite stays
+    # runnable against arbitrary labs.
+    function Assert-ApprovalPreconditionOrSkip
+    {
+        param([Parameter(Mandatory)] [string] $Because)
+
+        if ($env:TF_BUILD)
+        {
+            throw "Approval test precondition failed on the pipeline gate: $Because"
+        }
+
+        Set-ItResult -Skipped -Because $Because
+    }
+
     # Connects the module's shared client as an explicit user, reusing the same endpoint and
     # mode-aware SPN defaults as Connect-TestClient so only the identity differs. Used to raise the
     # membership request as the second user; the approver connection is restored afterwards with
@@ -142,7 +158,7 @@ Describe 'Get-ApprovalRequest / Set-PendingApprovalRequest' {
 
             if (-not $owner -or -not $member)
             {
-                Set-ItResult -Skipped -Because 'the approver (current user) and/or the second requestor could not be resolved as Person objects in this lab, so the approval scenario cannot be established'
+                Assert-ApprovalPreconditionOrSkip -Because 'the approver (current user) and/or the second requestor could not be resolved as Person objects in this lab, so the approval scenario cannot be established'
                 return
             }
 
@@ -173,7 +189,7 @@ Describe 'Get-ApprovalRequest / Set-PendingApprovalRequest' {
             $target = Get-GuidText $requestRef
             if (-not $target)
             {
-                Set-ItResult -Skipped -Because 'the membership change raised no pending ApprovalRequest - this lab has no approval workflow + MPR (e.g. the built-in ''Owner Approval'' workflow) bound to the target object type, so there is nothing for Get-ApprovalRequest / Set-PendingApprovalRequest to act on'
+                Assert-ApprovalPreconditionOrSkip -Because 'the membership change raised no pending ApprovalRequest - this lab has no approval workflow + MPR (e.g. the built-in ''Owner Approval'' workflow) bound to the target object type, so there is nothing for Get-ApprovalRequest / Set-PendingApprovalRequest to act on'
                 return
             }
 
@@ -230,7 +246,7 @@ Describe 'Get-ApprovalRequest / Set-PendingApprovalRequest' {
 
             if (-not $owner -or -not $member)
             {
-                Set-ItResult -Skipped -Because 'the approver (current user) and/or the second requestor could not be resolved as Person objects in this lab, so the approval scenario cannot be established'
+                Assert-ApprovalPreconditionOrSkip -Because 'the approver (current user) and/or the second requestor could not be resolved as Person objects in this lab, so the approval scenario cannot be established'
                 return
             }
 
@@ -258,7 +274,7 @@ Describe 'Get-ApprovalRequest / Set-PendingApprovalRequest' {
             $target = Get-GuidText $requestRef
             if (-not $target)
             {
-                Set-ItResult -Skipped -Because 'the membership change raised no pending ApprovalRequest - this lab has no approval workflow + MPR (e.g. the built-in ''Owner Approval'' workflow) bound to the target object type, so there is nothing for Get-ApprovalRequest / Set-PendingApprovalRequest to act on'
+                Assert-ApprovalPreconditionOrSkip -Because 'the membership change raised no pending ApprovalRequest - this lab has no approval workflow + MPR (e.g. the built-in ''Owner Approval'' workflow) bound to the target object type, so there is nothing for Get-ApprovalRequest / Set-PendingApprovalRequest to act on'
                 return
             }
 

--- a/test/LithnetRMA.Tests/Approval.Tests.ps1
+++ b/test/LithnetRMA.Tests/Approval.Tests.ps1
@@ -1,0 +1,301 @@
+<#
+    Cmdlet equivalent of the client unit tests' ApprovalTests.cs. Exercises Get-ApprovalRequest +
+    Set-PendingApprovalRequest against a real MIM approval flow and asserts what the cmdlet surface
+    exposes: a membership change that requires approval raises a pending ApprovalRequest that the
+    approver can retrieve, approve, or reject, and the request then leaves the Pending set and appears
+    in the Approved / Rejected set.
+
+    ApprovalTests.cs has two logical scenarios - TestApprovalForCurrentUser and
+    TestRejectionForCurrentUser - each run once per connection mode (ConnectionModeSourcesApprovals
+    yields LocalProxy and RemoteProxy on .NET/PowerShell 7). That is the four cases ported here:
+    approve x {LocalProxy, RemoteProxy} and reject x {LocalProxy, RemoteProxy}. The transport
+    difference is pinned too: retrieving approvals is a plain search and works everywhere
+    (asserted over DirectNetTcp in a dedicated case), but ACTIONING one uses the approval
+    endpoint, which net.tcp lacks (the client wires NotImplementedApprovalClient into its NetTcp
+    transport) - the approve scenario asserts that failure against a genuine pending approval on
+    both PowerShell editions.
+
+    Honest runnability - the real approval flow cannot be manufactured from the cmdlets alone. It has
+    two preconditions that live in lab MIM policy, not in the module:
+
+      1. A SECOND requestor credential. The current user (who runs the suite) is the group Owner and
+         therefore the approver; a request they raise against their own group is auto-authorized and
+         produces no approval. A DIFFERENT user must raise the membership request so the approval is
+         routed to the owner. In the client unit tests this is the 'mimuser' account from App.config
+         (approvalClientUser / approvalClientUserDomain / approvalClientUserPassword). That credential
+         cannot be created through the module's cmdlets and is not supplied by _Bootstrap, so it is
+         read from the environment (LITHNETRMA_TEST_APPROVAL_USER / _DOMAIN / _PASSWORD). When it is
+         absent the case is Skipped rather than faked.
+
+      2. An approval workflow + MPR bound to the target object type so the membership change generates
+         a pending ApprovalRequest (the client tests use the built-in Group 'Owner Approval'
+         workflow). If the lab has no such policy the membership change raises no request; the case is
+         then Skipped.
+
+    Where both preconditions are present the case runs for real and asserts the cmdlet-observable
+    state change. Note that Get-ApprovalRequest exposes only the status-only overload, which filters
+    to the connected (approver) identity - so the C# retrievals "by owner ObjectID" and "by current
+    context" both map to Get-ApprovalRequest -Status Pending here.
+
+    Save-Resource does not throw when a change requires authorization: the cmdlet catches the
+    AuthorizationRequiredException and writes the pending request reference to the pipeline, so the
+    request id is simply Save-Resource's output.
+#>
+
+BeforeAll {
+    . $PSScriptRoot/_Bootstrap.ps1
+    $script:data = Get-TestData
+    $script:refs = Initialize-ReferenceObjects
+
+    # Second requestor credential (mirrors ApprovalTests.cs' standardUserCredentials / App.config
+    # approvalClientUser). Absent by default; supply via environment to enable the real flow.
+    $approvalUser     = $env:LITHNETRMA_TEST_APPROVAL_USER
+    $approvalDomain   = $env:LITHNETRMA_TEST_APPROVAL_DOMAIN
+    $approvalPassword = $env:LITHNETRMA_TEST_APPROVAL_PASSWORD
+
+    if ($approvalUser -and $approvalPassword)
+    {
+        $userNameForLogon = if ($approvalDomain) { "$approvalDomain\$approvalUser" } else { $approvalUser }
+        $securePassword = ConvertTo-SecureString $approvalPassword -AsPlainText -Force
+        $script:approvalCred = New-Object System.Management.Automation.PSCredential($userNameForLogon, $securePassword)
+        $script:approvalUser = $approvalUser
+    }
+    else
+    {
+        $script:approvalCred = $null
+        $script:approvalUser = $null
+    }
+
+    # In a pipeline run (TF_BUILD is set by Azure DevOps) the approval tests are mandatory: they
+    # exercise the most complex flow in the product, so a missing credential must fail the gate
+    # loudly rather than silently skipping them. Locally, skipping remains fine.
+    function Assert-ApprovalCredentialOrSkip
+    {
+        param([Parameter(Mandatory)] [string] $Because)
+
+        if ($script:approvalCred)
+        {
+            return $true
+        }
+
+        if ($env:TF_BUILD)
+        {
+            throw 'The approval test credential (LITHNETRMA_TEST_APPROVAL_USER / _DOMAIN / _PASSWORD) is not available to this pipeline run. The approval tests are a mandatory part of the release gate; check that the ''MIM lab test credentials'' variable group is linked and the secret is mapped into the step environment.'
+        }
+
+        Set-ItResult -Skipped -Because $Because
+        return $false
+    }
+
+    # Connects the module's shared client as an explicit user, reusing the same endpoint and
+    # mode-aware SPN defaults as Connect-TestClient so only the identity differs. Used to raise the
+    # membership request as the second user; the approver connection is restored afterwards with
+    # Connect-TestClient.
+    function Connect-AsUser
+    {
+        param(
+            [Parameter(Mandatory)] [pscredential] $Credential,
+            [string] $ConnectionMode = 'LocalProxy'
+        )
+        Connect-TestClient -ConnectionMode $ConnectionMode -Credential $Credential
+    }
+
+    # Normalises any reference value (UniqueIdentifier, 'urn:uuid:...' text, or bare guid) to a
+    # canonical lowercase guid string so the pending-request reference and an approval's Request
+    # attribute can be compared regardless of representation.
+    function Get-GuidText
+    {
+        param($Value)
+        if ($null -eq $Value) { return $null }
+        $match = [regex]::Match([string]$Value, '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}')
+        if ($match.Success) { return $match.Value.ToLowerInvariant() }
+        return $null
+    }
+}
+
+Describe 'Get-ApprovalRequest / Set-PendingApprovalRequest' {
+
+    BeforeEach {
+        $script:created = [System.Collections.Generic.List[object]]::new()
+    }
+
+    AfterEach {
+        foreach ($id in $script:created) { $id | Remove-TestResource }
+    }
+
+    It 'approves a pending membership request for the current user (<Mode>)' -Tag 'RequiresApprovalWorkflow', 'RequiresSecondUser' -ForEach @(
+        @{ Mode = 'LocalProxy' }
+        @{ Mode = 'RemoteProxy' }
+    ) {
+        if (-not (Assert-ApprovalCredentialOrSkip -Because 'needs a second requestor credential to raise the membership request the current user then approves. Set LITHNETRMA_TEST_APPROVAL_USER / LITHNETRMA_TEST_APPROVAL_DOMAIN / LITHNETRMA_TEST_APPROVAL_PASSWORD to enable.'))
+        {
+            return
+        }
+
+        try
+        {
+            # Approver == current user, in this connection mode.
+            Connect-TestClient -ConnectionMode $Mode
+
+            $owner  = Get-Resource -ObjectType Person -AttributeName AccountName -AttributeValue $env:USERNAME
+            $member = Get-Resource -ObjectType Person -AttributeName AccountName -AttributeValue $script:approvalUser
+
+            if (-not $owner -or -not $member)
+            {
+                Set-ItResult -Skipped -Because 'the approver (current user) and/or the second requestor could not be resolved as Person objects in this lab, so the approval scenario cannot be established'
+                return
+            }
+
+            $groupName = [Guid]::NewGuid().ToString()
+            $group = New-Resource -ObjectType Group
+            $group.AccountName           = $groupName
+            $group.DisplayName           = "Unit test approval group $groupName"
+            $group.Owner                 = $owner.ObjectID
+            $group.DisplayedOwner        = $owner.ObjectID
+            $group.Scope                 = 'Global'
+            $group.Type                  = 'Security'
+            $group.Domain                = $env:USERDOMAIN
+            $group.MembershipLocked      = $false
+            $group.MembershipAddWorkflow = 'Owner Approval'
+            Save-Resource $group
+            $script:created.Add($group.ObjectID)
+
+            # Raise the membership request as the SECOND user. Save-Resource emits the pending request
+            # reference when the change requires authorization.
+            Connect-AsUser -Credential $script:approvalCred -ConnectionMode $Mode
+            $group2 = Get-Resource -ID $group.ObjectID
+            $group2.ExplicitMember = @($member.ObjectID)
+            $requestRef = Save-Resource $group2
+
+            # Back to the approver to retrieve and act on the request.
+            Connect-TestClient -ConnectionMode $Mode
+
+            $target = Get-GuidText $requestRef
+            if (-not $target)
+            {
+                Set-ItResult -Skipped -Because 'the membership change raised no pending ApprovalRequest - this lab has no approval workflow + MPR (e.g. the built-in ''Owner Approval'' workflow) bound to the target object type, so there is nothing for Get-ApprovalRequest / Set-PendingApprovalRequest to act on'
+                return
+            }
+
+            $pending = @(Get-ApprovalRequest -Status Pending)
+            $ours = $pending | Where-Object { (Get-GuidText $_.Request) -eq $target }
+            $ours | Should -Not -BeNullOrEmpty -Because 'the pending request must be retrievable via Get-ApprovalRequest -Status Pending'
+
+            # Approvals cannot be ACTIONED over net.tcp: the client wires a
+            # NotImplementedApprovalClient into its NetTcp transport because the FIM approval
+            # endpoint has no net.tcp binding. Pin the intended failure here, against a genuine
+            # pending approval, so it can never silently turn into a hang or a no-op. The client
+            # is a single netstandard assembly, so this holds on both PowerShell editions.
+            Connect-TestClient -ConnectionMode DirectNetTcp
+            $overNetTcp = @(Get-ApprovalRequest -Status Pending) | Where-Object { (Get-GuidText $_.Request) -eq $target }
+            $overNetTcp | Should -Not -BeNullOrEmpty -Because 'retrieving approvals is a plain search and works on every transport'
+            { $overNetTcp | Set-PendingApprovalRequest -Decision Approve -Reason 'Must fail over net.tcp' } | Should -Throw
+            Connect-TestClient -ConnectionMode $Mode
+
+            $ours | Set-PendingApprovalRequest -Decision Approve -Reason 'Test reason for approval'
+
+            # The approval decision is processed asynchronously by the MIM workflow (mirrors the
+            # client test's post-approve wait).
+            Start-Sleep -Seconds 5
+
+            $stillPending = @(Get-ApprovalRequest -Status Pending) | Where-Object { (Get-GuidText $_.Request) -eq $target }
+            $stillPending | Should -BeNullOrEmpty -Because 'an approved request must no longer appear in the Pending set'
+
+            $approved = @(Get-ApprovalRequest -Status Approved) | Where-Object { (Get-GuidText $_.Request) -eq $target }
+            $approved | Should -Not -BeNullOrEmpty -Because 'the request must move to the Approved set once approved'
+        }
+        finally
+        {
+            # Restore a known-good approver connection so cleanup (and the next test) run as the
+            # current user regardless of where the flow left off.
+            Connect-TestClient
+        }
+    }
+
+    It 'rejects a pending membership request for the current user (<Mode>)' -Tag 'RequiresApprovalWorkflow', 'RequiresSecondUser' -ForEach @(
+        @{ Mode = 'LocalProxy' }
+        @{ Mode = 'RemoteProxy' }
+    ) {
+        if (-not (Assert-ApprovalCredentialOrSkip -Because 'needs a second requestor credential to raise the membership request the current user then rejects. Set LITHNETRMA_TEST_APPROVAL_USER / LITHNETRMA_TEST_APPROVAL_DOMAIN / LITHNETRMA_TEST_APPROVAL_PASSWORD to enable.'))
+        {
+            return
+        }
+
+        try
+        {
+            Connect-TestClient -ConnectionMode $Mode
+
+            $owner  = Get-Resource -ObjectType Person -AttributeName AccountName -AttributeValue $env:USERNAME
+            $member = Get-Resource -ObjectType Person -AttributeName AccountName -AttributeValue $script:approvalUser
+
+            if (-not $owner -or -not $member)
+            {
+                Set-ItResult -Skipped -Because 'the approver (current user) and/or the second requestor could not be resolved as Person objects in this lab, so the approval scenario cannot be established'
+                return
+            }
+
+            $groupName = [Guid]::NewGuid().ToString()
+            $group = New-Resource -ObjectType Group
+            $group.AccountName           = $groupName
+            $group.DisplayName           = "Unit test approval group $groupName"
+            $group.Owner                 = $owner.ObjectID
+            $group.DisplayedOwner        = $owner.ObjectID
+            $group.Scope                 = 'Global'
+            $group.Type                  = 'Security'
+            $group.Domain                = $env:USERDOMAIN
+            $group.MembershipLocked      = $false
+            $group.MembershipAddWorkflow = 'Owner Approval'
+            Save-Resource $group
+            $script:created.Add($group.ObjectID)
+
+            Connect-AsUser -Credential $script:approvalCred -ConnectionMode $Mode
+            $group2 = Get-Resource -ID $group.ObjectID
+            $group2.ExplicitMember = @($member.ObjectID)
+            $requestRef = Save-Resource $group2
+
+            Connect-TestClient -ConnectionMode $Mode
+
+            $target = Get-GuidText $requestRef
+            if (-not $target)
+            {
+                Set-ItResult -Skipped -Because 'the membership change raised no pending ApprovalRequest - this lab has no approval workflow + MPR (e.g. the built-in ''Owner Approval'' workflow) bound to the target object type, so there is nothing for Get-ApprovalRequest / Set-PendingApprovalRequest to act on'
+                return
+            }
+
+            $pending = @(Get-ApprovalRequest -Status Pending)
+            $ours = $pending | Where-Object { (Get-GuidText $_.Request) -eq $target }
+            $ours | Should -Not -BeNullOrEmpty -Because 'the pending request must be retrievable via Get-ApprovalRequest -Status Pending'
+
+            $ours | Set-PendingApprovalRequest -Decision Reject -Reason 'Test reason for rejection'
+
+            Start-Sleep -Seconds 5
+
+            $stillPending = @(Get-ApprovalRequest -Status Pending) | Where-Object { (Get-GuidText $_.Request) -eq $target }
+            $stillPending | Should -BeNullOrEmpty -Because 'a rejected request must no longer appear in the Pending set'
+
+            $rejected = @(Get-ApprovalRequest -Status Rejected) | Where-Object { (Get-GuidText $_.Request) -eq $target }
+            $rejected | Should -Not -BeNullOrEmpty -Because 'the request must move to the Rejected set once rejected'
+        }
+        finally
+        {
+            Connect-TestClient
+        }
+    }
+
+    It 'retrieves approval requests over DirectNetTcp' {
+        # Retrieving approvals is a plain XPath search over /Approval
+        # (ResourceManagementClient.GetApprovalsAsync), so it works on every transport, including
+        # net.tcp. Only ACTING on an approval uses the approval endpoint, which net.tcp lacks -
+        # that intended failure is pinned inside the approve scenario, where a genuine pending
+        # approval exists to attempt.
+        try
+        {
+            Connect-TestClient -ConnectionMode DirectNetTcp
+            { Get-ApprovalRequest -Status Pending } | Should -Not -Throw
+        }
+        finally
+        {
+            Connect-TestClient
+        }
+    }
+}

--- a/test/LithnetRMA.Tests/Attributes.Tests.ps1
+++ b/test/LithnetRMA.Tests/Attributes.Tests.ps1
@@ -1,0 +1,638 @@
+<#
+    Cmdlet equivalent of the client unit tests' Put*Tests.cs (one file per data type). Each of those
+    C# files exercises, per attribute type, the same three-part pattern against an already-persisted
+    object: (a) set a value and verify it round-trips, (b) modify the value and verify, (c) clear the
+    value and verify it becomes null/empty - with single-valued (SV) and multi-valued (MV) variants.
+
+    This suite ports those cases to what the cmdlet surface can observe. The C# tests assert on
+    internal AttributeValue state (PendingChanges.Count, the client type's IsNull flag) that the
+    cmdlets do not expose; the observable equivalent is simply "the re-read note-property equals the
+    expected value / is null / is empty", so those internal-state assertions are dropped and only the
+    round-tripped value is checked.
+
+    Model (per the module): New-Resource builds an object, note-properties carry attribute values,
+    Save-Resource persists, Get-Resource -ID re-reads. Setting an SV to $null or an MV to @() and
+    saving clears it. References are set/read as ObjectIDs and compared by string form.
+#>
+
+BeforeAll {
+    . $PSScriptRoot/_Bootstrap.ps1
+    $script:data = Get-TestData
+    $script:refs = Initialize-ReferenceObjects
+
+    # Second-value test data, mirroring the '...2' / '...3' constants in Constants.cs. These are the
+    # values the modify cases change TO, and the two distinct strings the composite case writes. The
+    # DateTime values are derived from the already second-truncated, UTC DateTime1/DateTime1MV so they
+    # round-trip without rounding drift, exactly as Constants.cs derives its DateTime constants.
+    $script:data2 = @{
+        String2     = 'testString2'
+        String3     = 'testString3'
+        String2MV   = @('testString7', 'testString8', 'testString9')
+        Integer2    = [long]5
+        Integer2MV  = @([long]16, [long]17, [long]18)
+        Text2       = 'testText2'
+        Text2MV     = @('testText7', 'testText8', 'testText9')
+        Binary2     = [byte[]]@(4, 5, 6, 7)
+        Binary2MV   = @(, [byte[]]@(24, 25, 26, 27)) + @(, [byte[]]@(28, 29, 30, 31)) + @(, [byte[]]@(32, 33, 34, 35))
+        DateTime2   = $script:data.DateTime1.AddDays(1)
+        DateTime2MV = @($script:data.DateTime1MV | ForEach-Object { $_.AddDays(3) })
+    }
+
+    function New-PutResource
+    {
+        <# Creates a _unitTestObject with a unique, greppable account name, persists it, registers its
+           ObjectID for AfterEach cleanup, and returns the saved object ready to be modified. #>
+        $r = New-Resource -ObjectType $script:data.UnitTestObjectType
+        $r.($script:data.Attr.AccountName) = "put-$([Guid]::NewGuid().ToString('N'))"
+        Save-Resource $r
+        $script:created.Add($r.ObjectID)
+        return $r
+    }
+
+    function Save-AndReget
+    {
+        <# Persists pending changes on a resource then returns a freshly re-read copy, so assertions
+           always run against what the service actually stored (mirrors the C# save + GetResource). #>
+        param([Parameter(Mandatory)] $Resource)
+        Save-Resource $Resource
+        return Get-Resource -ID $Resource.ObjectID
+    }
+
+    function ConvertTo-UtcSecondsList
+    {
+        <# Normalises a collection of datetimes to UTC, whole-second strings for instant-based,
+           order-sensitive comparison (the list form of ConvertTo-UtcSeconds). #>
+        param($Values)
+        return @($Values | ForEach-Object { ConvertTo-UtcSeconds $_ })
+    }
+
+    function ConvertTo-StringList
+    {
+        <# Projects a collection (e.g. reference ObjectIDs) to their string form for comparison. #>
+        param($Values)
+        return @($Values | ForEach-Object { "$_" })
+    }
+
+    function Assert-BinaryEqual
+    {
+        <# Byte-by-byte comparison of a single binary value. #>
+        param($Actual, $Expected)
+        $a = [byte[]] $Actual
+        $e = [byte[]] $Expected
+        $a.Length | Should -Be $e.Length -Because 'the binary values must have the same length'
+        for ($i = 0; $i -lt $e.Length; $i++)
+        {
+            $a[$i] | Should -Be $e[$i] -Because "the byte at index $i must match"
+        }
+    }
+
+    function Assert-BinaryCollection
+    {
+        <# Element-by-element byte comparison of a multi-valued binary attribute, order-sensitive. #>
+        param($Actual, $Expected)
+        $a = @($Actual)
+        $e = @($Expected)
+        $a.Count | Should -Be $e.Count -Because 'the binary collections must have the same number of values'
+        for ($i = 0; $i -lt $e.Count; $i++)
+        {
+            Assert-BinaryEqual $a[$i] $e[$i]
+        }
+    }
+}
+
+Describe 'Attribute value round-trips (Put*Tests)' {
+
+    BeforeEach {
+        $script:created = [System.Collections.Generic.List[object]]::new()
+    }
+
+    AfterEach {
+        foreach ($id in $script:created) { $id | Remove-TestResource }
+    }
+
+    # --- String -----------------------------------------------------------------------------------
+    # Ports PutStringTests.cs. AddStringSV/ModifyStringSV/DeleteStringSV/DeleteAllValueStringSV and the
+    # MV set AddFirst/AddSecond/Replace/DeleteFirstValue/DeleteAllValue. ModifyStringSVNoUpdate is
+    # dropped: it only asserts PendingChanges.Count == 0, which is not observable through the cmdlets.
+    # DeleteStringSV and DeleteAllValueStringSV collapse to one "clears" case (both null the SV).
+
+    Context 'String (single-valued)' {
+
+        It 'sets a value on an existing object' {
+            $r = New-PutResource
+            $r.ut_svstring = $script:data.String1
+            $r = Save-AndReget $r
+            $r.ut_svstring | Should -Be $script:data.String1
+        }
+
+        It 'modifies an existing value' {
+            $r = New-PutResource
+            $r.ut_svstring = $script:data.String1
+            $r = Save-AndReget $r
+            $r.ut_svstring = $script:data2.String2
+            $r = Save-AndReget $r
+            $r.ut_svstring | Should -Be $script:data2.String2
+        }
+
+        It 'clears the value' {
+            $r = New-PutResource
+            $r.ut_svstring = $script:data.String1
+            $r = Save-AndReget $r
+            $r.ut_svstring = $null
+            $r = Save-AndReget $r
+            $r.ut_svstring | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'String (multi-valued)' {
+
+        It 'sets values on an existing object' {
+            $r = New-PutResource
+            $r.ut_mvstring = $script:data.String1MV
+            $r = Save-AndReget $r
+            @($r.ut_mvstring) | Should -Be $script:data.String1MV
+        }
+
+        It 'grows the collection with a further value' {
+            $r = New-PutResource
+            $r.ut_mvstring = $script:data.String1MV[0..1]
+            $r = Save-AndReget $r
+            $r.ut_mvstring = $script:data.String1MV
+            $r = Save-AndReget $r
+            @($r.ut_mvstring) | Should -Be $script:data.String1MV
+        }
+
+        It 'replaces all values' {
+            $r = New-PutResource
+            $r.ut_mvstring = $script:data.String1MV
+            $r = Save-AndReget $r
+            $r.ut_mvstring = $script:data2.String2MV
+            $r = Save-AndReget $r
+            @($r.ut_mvstring) | Should -Be $script:data2.String2MV
+        }
+
+        It 'removes one value' {
+            $r = New-PutResource
+            $r.ut_mvstring = $script:data.String1MV
+            $r = Save-AndReget $r
+            $r.ut_mvstring = $script:data.String1MV[1..2]
+            $r = Save-AndReget $r
+            @($r.ut_mvstring) | Should -Be $script:data.String1MV[1..2]
+        }
+
+        It 'clears all values' {
+            $r = New-PutResource
+            $r.ut_mvstring = $script:data.String1MV
+            $r = Save-AndReget $r
+            $r.ut_mvstring = @()
+            $r = Save-AndReget $r
+            @($r.ut_mvstring).Count | Should -Be 0
+        }
+    }
+
+    # --- Integer ----------------------------------------------------------------------------------
+    # Ports PutIntegerTests.cs.
+
+    Context 'Integer (single-valued)' {
+
+        It 'sets a value on an existing object' {
+            $r = New-PutResource
+            $r.ut_svinteger = $script:data.Integer1
+            $r = Save-AndReget $r
+            $r.ut_svinteger | Should -Be $script:data.Integer1
+        }
+
+        It 'modifies an existing value' {
+            $r = New-PutResource
+            $r.ut_svinteger = $script:data.Integer1
+            $r = Save-AndReget $r
+            $r.ut_svinteger = $script:data2.Integer2
+            $r = Save-AndReget $r
+            $r.ut_svinteger | Should -Be $script:data2.Integer2
+        }
+
+        It 'clears the value' {
+            $r = New-PutResource
+            $r.ut_svinteger = $script:data.Integer1
+            $r = Save-AndReget $r
+            $r.ut_svinteger = $null
+            $r = Save-AndReget $r
+            $r.ut_svinteger | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Integer (multi-valued)' {
+
+        It 'sets values on an existing object' {
+            $r = New-PutResource
+            $r.ut_mvinteger = $script:data.Integer1MV
+            $r = Save-AndReget $r
+            @($r.ut_mvinteger) | Should -Be $script:data.Integer1MV
+        }
+
+        It 'grows the collection with a further value' {
+            $r = New-PutResource
+            $r.ut_mvinteger = $script:data.Integer1MV[0..1]
+            $r = Save-AndReget $r
+            $r.ut_mvinteger = $script:data.Integer1MV
+            $r = Save-AndReget $r
+            @($r.ut_mvinteger) | Should -Be $script:data.Integer1MV
+        }
+
+        It 'replaces all values' {
+            $r = New-PutResource
+            $r.ut_mvinteger = $script:data.Integer1MV
+            $r = Save-AndReget $r
+            $r.ut_mvinteger = $script:data2.Integer2MV
+            $r = Save-AndReget $r
+            @($r.ut_mvinteger) | Should -Be $script:data2.Integer2MV
+        }
+
+        It 'removes one value' {
+            $r = New-PutResource
+            $r.ut_mvinteger = $script:data.Integer1MV
+            $r = Save-AndReget $r
+            $r.ut_mvinteger = $script:data.Integer1MV[1..2]
+            $r = Save-AndReget $r
+            @($r.ut_mvinteger) | Should -Be $script:data.Integer1MV[1..2]
+        }
+
+        It 'clears all values' {
+            $r = New-PutResource
+            $r.ut_mvinteger = $script:data.Integer1MV
+            $r = Save-AndReget $r
+            $r.ut_mvinteger = @()
+            $r = Save-AndReget $r
+            @($r.ut_mvinteger).Count | Should -Be 0
+        }
+    }
+
+    # --- Text -------------------------------------------------------------------------------------
+    # Ports PutTextTests.cs (the Text data type has both SV and MV cases in the client tests).
+
+    Context 'Text (single-valued)' {
+
+        It 'sets a value on an existing object' {
+            $r = New-PutResource
+            $r.ut_svtext = $script:data.Text1
+            $r = Save-AndReget $r
+            $r.ut_svtext | Should -Be $script:data.Text1
+        }
+
+        It 'modifies an existing value' {
+            $r = New-PutResource
+            $r.ut_svtext = $script:data.Text1
+            $r = Save-AndReget $r
+            $r.ut_svtext = $script:data2.Text2
+            $r = Save-AndReget $r
+            $r.ut_svtext | Should -Be $script:data2.Text2
+        }
+
+        It 'clears the value' {
+            $r = New-PutResource
+            $r.ut_svtext = $script:data.Text1
+            $r = Save-AndReget $r
+            $r.ut_svtext = $null
+            $r = Save-AndReget $r
+            $r.ut_svtext | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Text (multi-valued)' {
+
+        It 'sets values on an existing object' {
+            $r = New-PutResource
+            $r.ut_mvtext = $script:data.Text1MV
+            $r = Save-AndReget $r
+            @($r.ut_mvtext) | Should -Be $script:data.Text1MV
+        }
+
+        It 'grows the collection with a further value' {
+            $r = New-PutResource
+            $r.ut_mvtext = $script:data.Text1MV[0..1]
+            $r = Save-AndReget $r
+            $r.ut_mvtext = $script:data.Text1MV
+            $r = Save-AndReget $r
+            @($r.ut_mvtext) | Should -Be $script:data.Text1MV
+        }
+
+        It 'replaces all values' {
+            $r = New-PutResource
+            $r.ut_mvtext = $script:data.Text1MV
+            $r = Save-AndReget $r
+            $r.ut_mvtext = $script:data2.Text2MV
+            $r = Save-AndReget $r
+            @($r.ut_mvtext) | Should -Be $script:data2.Text2MV
+        }
+
+        It 'removes one value' {
+            $r = New-PutResource
+            $r.ut_mvtext = $script:data.Text1MV
+            $r = Save-AndReget $r
+            $r.ut_mvtext = $script:data.Text1MV[1..2]
+            $r = Save-AndReget $r
+            @($r.ut_mvtext) | Should -Be $script:data.Text1MV[1..2]
+        }
+
+        It 'clears all values' {
+            $r = New-PutResource
+            $r.ut_mvtext = $script:data.Text1MV
+            $r = Save-AndReget $r
+            $r.ut_mvtext = @()
+            $r = Save-AndReget $r
+            @($r.ut_mvtext).Count | Should -Be 0
+        }
+    }
+
+    # --- Boolean ----------------------------------------------------------------------------------
+    # Ports PutBooleanTests.cs (SV only). Modify goes true -> false. The "clears" case checks that a
+    # cleared boolean re-reads as null, distinct from a stored $false.
+
+    Context 'Boolean (single-valued)' {
+
+        It 'sets a value on an existing object' {
+            $r = New-PutResource
+            $r.ut_svboolean = $script:data.BooleanTrue
+            $r = Save-AndReget $r
+            $r.ut_svboolean | Should -Be $script:data.BooleanTrue
+        }
+
+        It 'modifies an existing value' {
+            $r = New-PutResource
+            $r.ut_svboolean = $true
+            $r = Save-AndReget $r
+            $r.ut_svboolean = $false
+            $r = Save-AndReget $r
+            $r.ut_svboolean | Should -Be $false
+        }
+
+        It 'clears the value' {
+            $r = New-PutResource
+            $r.ut_svboolean = $true
+            $r = Save-AndReget $r
+            $r.ut_svboolean = $null
+            $r = Save-AndReget $r
+            $r.ut_svboolean | Should -BeNullOrEmpty
+        }
+    }
+
+    # --- DateTime ---------------------------------------------------------------------------------
+    # Ports PutDateTimeTests.cs. All datetimes compared instant-based via ConvertTo-UtcSeconds.
+
+    Context 'DateTime (single-valued)' {
+
+        It 'sets a value on an existing object' {
+            $r = New-PutResource
+            $r.ut_svdatetime = $script:data.DateTime1
+            $r = Save-AndReget $r
+            (ConvertTo-UtcSeconds $r.ut_svdatetime) | Should -Be (ConvertTo-UtcSeconds $script:data.DateTime1)
+        }
+
+        It 'modifies an existing value' {
+            $r = New-PutResource
+            $r.ut_svdatetime = $script:data.DateTime1
+            $r = Save-AndReget $r
+            $r.ut_svdatetime = $script:data2.DateTime2
+            $r = Save-AndReget $r
+            (ConvertTo-UtcSeconds $r.ut_svdatetime) | Should -Be (ConvertTo-UtcSeconds $script:data2.DateTime2)
+        }
+
+        It 'clears the value' {
+            $r = New-PutResource
+            $r.ut_svdatetime = $script:data.DateTime1
+            $r = Save-AndReget $r
+            $r.ut_svdatetime = $null
+            $r = Save-AndReget $r
+            $r.ut_svdatetime | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'DateTime (multi-valued)' {
+
+        It 'sets values on an existing object' {
+            $r = New-PutResource
+            $r.ut_mvdatetime = $script:data.DateTime1MV
+            $r = Save-AndReget $r
+            (ConvertTo-UtcSecondsList $r.ut_mvdatetime) | Should -Be (ConvertTo-UtcSecondsList $script:data.DateTime1MV)
+        }
+
+        It 'grows the collection with a further value' {
+            $r = New-PutResource
+            $r.ut_mvdatetime = $script:data.DateTime1MV[0..1]
+            $r = Save-AndReget $r
+            $r.ut_mvdatetime = $script:data.DateTime1MV
+            $r = Save-AndReget $r
+            (ConvertTo-UtcSecondsList $r.ut_mvdatetime) | Should -Be (ConvertTo-UtcSecondsList $script:data.DateTime1MV)
+        }
+
+        It 'replaces all values' {
+            $r = New-PutResource
+            $r.ut_mvdatetime = $script:data.DateTime1MV
+            $r = Save-AndReget $r
+            $r.ut_mvdatetime = $script:data2.DateTime2MV
+            $r = Save-AndReget $r
+            (ConvertTo-UtcSecondsList $r.ut_mvdatetime) | Should -Be (ConvertTo-UtcSecondsList $script:data2.DateTime2MV)
+        }
+
+        It 'removes one value' {
+            $r = New-PutResource
+            $r.ut_mvdatetime = $script:data.DateTime1MV
+            $r = Save-AndReget $r
+            $r.ut_mvdatetime = $script:data.DateTime1MV[1..2]
+            $r = Save-AndReget $r
+            (ConvertTo-UtcSecondsList $r.ut_mvdatetime) | Should -Be (ConvertTo-UtcSecondsList $script:data.DateTime1MV[1..2])
+        }
+
+        It 'clears all values' {
+            $r = New-PutResource
+            $r.ut_mvdatetime = $script:data.DateTime1MV
+            $r = Save-AndReget $r
+            $r.ut_mvdatetime = @()
+            $r = Save-AndReget $r
+            @($r.ut_mvdatetime).Count | Should -Be 0
+        }
+    }
+
+    # --- Binary -----------------------------------------------------------------------------------
+    # Ports PutBinaryTests.cs. Binary values compared byte-by-byte (Assert-BinaryEqual /
+    # Assert-BinaryCollection). MV states are built from array slices to keep each element an
+    # intact byte[] (wrapping a single byte[] in @() would flatten it into individual bytes).
+
+    Context 'Binary (single-valued)' {
+
+        It 'sets a value on an existing object' {
+            $r = New-PutResource
+            $r.ut_svbinary = $script:data.Binary1
+            $r = Save-AndReget $r
+            Assert-BinaryEqual $r.ut_svbinary $script:data.Binary1
+        }
+
+        It 'modifies an existing value' {
+            $r = New-PutResource
+            $r.ut_svbinary = $script:data.Binary1
+            $r = Save-AndReget $r
+            $r.ut_svbinary = $script:data2.Binary2
+            $r = Save-AndReget $r
+            Assert-BinaryEqual $r.ut_svbinary $script:data2.Binary2
+        }
+
+        It 'clears the value' {
+            $r = New-PutResource
+            $r.ut_svbinary = $script:data.Binary1
+            $r = Save-AndReget $r
+            $r.ut_svbinary = $null
+            $r = Save-AndReget $r
+            $r.ut_svbinary | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Binary (multi-valued)' {
+
+        It 'sets values on an existing object' {
+            $r = New-PutResource
+            $r.ut_mvbinary = $script:data.Binary1MV
+            $r = Save-AndReget $r
+            Assert-BinaryCollection $r.ut_mvbinary $script:data.Binary1MV
+        }
+
+        It 'grows the collection with a further value' {
+            $r = New-PutResource
+            $r.ut_mvbinary = $script:data.Binary1MV[0..1]
+            $r = Save-AndReget $r
+            $r.ut_mvbinary = $script:data.Binary1MV
+            $r = Save-AndReget $r
+            Assert-BinaryCollection $r.ut_mvbinary $script:data.Binary1MV
+        }
+
+        It 'replaces all values' {
+            $r = New-PutResource
+            $r.ut_mvbinary = $script:data.Binary1MV
+            $r = Save-AndReget $r
+            $r.ut_mvbinary = $script:data2.Binary2MV
+            $r = Save-AndReget $r
+            Assert-BinaryCollection $r.ut_mvbinary $script:data2.Binary2MV
+        }
+
+        It 'removes one value' {
+            $r = New-PutResource
+            $r.ut_mvbinary = $script:data.Binary1MV
+            $r = Save-AndReget $r
+            $r.ut_mvbinary = $script:data.Binary1MV[1..2]
+            $r = Save-AndReget $r
+            Assert-BinaryCollection $r.ut_mvbinary $script:data.Binary1MV[1..2]
+        }
+
+        It 'clears all values' {
+            $r = New-PutResource
+            $r.ut_mvbinary = $script:data.Binary1MV
+            $r = Save-AndReget $r
+            $r.ut_mvbinary = @()
+            $r = Save-AndReget $r
+            @($r.ut_mvbinary).Count | Should -Be 0
+        }
+    }
+
+    # --- Reference --------------------------------------------------------------------------------
+    # Ports PutReferenceTests.cs. References are set from and compared to reftest1..6 ObjectIDs (never
+    # deleted). Ref1/Ref2 are the two single references; Ref1MV = {1,2,3}, Ref2MV = {4,5,6}. Compared
+    # by string form of the ObjectID.
+
+    Context 'Reference (single-valued)' {
+
+        It 'sets a value on an existing object' {
+            $r = New-PutResource
+            $r.ut_svreference = $script:refs.Ref1
+            $r = Save-AndReget $r
+            "$($r.ut_svreference)" | Should -Be "$($script:refs.Ref1)"
+        }
+
+        It 'modifies an existing value' {
+            $r = New-PutResource
+            $r.ut_svreference = $script:refs.Ref1
+            $r = Save-AndReget $r
+            $r.ut_svreference = $script:refs.Ref2
+            $r = Save-AndReget $r
+            "$($r.ut_svreference)" | Should -Be "$($script:refs.Ref2)"
+        }
+
+        It 'clears the value' {
+            $r = New-PutResource
+            $r.ut_svreference = $script:refs.Ref1
+            $r = Save-AndReget $r
+            $r.ut_svreference = $null
+            $r = Save-AndReget $r
+            $r.ut_svreference | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Reference (multi-valued)' {
+
+        It 'sets values on an existing object' {
+            $r = New-PutResource
+            $r.ut_mvreference = $script:refs.Ref1MV
+            $r = Save-AndReget $r
+            (ConvertTo-StringList $r.ut_mvreference) | Should -Be (ConvertTo-StringList $script:refs.Ref1MV)
+        }
+
+        It 'grows the collection with a further value' {
+            $r = New-PutResource
+            $r.ut_mvreference = $script:refs.Ref1MV[0..1]
+            $r = Save-AndReget $r
+            $r.ut_mvreference = $script:refs.Ref1MV
+            $r = Save-AndReget $r
+            (ConvertTo-StringList $r.ut_mvreference) | Should -Be (ConvertTo-StringList $script:refs.Ref1MV)
+        }
+
+        It 'replaces all values' {
+            $r = New-PutResource
+            $r.ut_mvreference = $script:refs.Ref1MV
+            $r = Save-AndReget $r
+            $r.ut_mvreference = $script:refs.Ref2MV
+            $r = Save-AndReget $r
+            (ConvertTo-StringList $r.ut_mvreference) | Should -Be (ConvertTo-StringList $script:refs.Ref2MV)
+        }
+
+        It 'removes one value' {
+            $r = New-PutResource
+            $r.ut_mvreference = $script:refs.Ref1MV
+            $r = Save-AndReget $r
+            $r.ut_mvreference = $script:refs.Ref1MV[1..2]
+            $r = Save-AndReget $r
+            (ConvertTo-StringList $r.ut_mvreference) | Should -Be (ConvertTo-StringList $script:refs.Ref1MV[1..2])
+        }
+
+        It 'clears all values' {
+            $r = New-PutResource
+            $r.ut_mvreference = $script:refs.Ref1MV
+            $r = Save-AndReget $r
+            $r.ut_mvreference = @()
+            $r = Save-AndReget $r
+            @($r.ut_mvreference).Count | Should -Be 0
+        }
+    }
+
+    # --- Composite --------------------------------------------------------------------------------
+    # Ports PutCompositeTests.cs: populate two objects, then change one attribute on each and persist
+    # both changes in a single Save-Resource of an array; verify each object round-trips its own value.
+
+    Context 'Composite (multiple resources in one save)' {
+
+        It 'saves changes to multiple resources in a single composite save' {
+            $r1 = New-PutResource
+            Set-TestUserData -Resource $r1 -Data $script:data -References $script:refs
+            $r1 = Save-AndReget $r1
+
+            $r2 = New-PutResource
+            Set-TestUserData -Resource $r2 -Data $script:data -References $script:refs
+            $r2 = Save-AndReget $r2
+
+            $r1.ut_svstring = $script:data2.String2
+            $r2.ut_svstring = $script:data2.String3
+
+            Save-Resource @($r1, $r2)
+
+            (Get-Resource -ID $r1.ObjectID).ut_svstring | Should -Be $script:data2.String2
+            (Get-Resource -ID $r2.ObjectID).ut_svstring | Should -Be $script:data2.String3
+        }
+    }
+}

--- a/test/LithnetRMA.Tests/Binding.Tests.ps1
+++ b/test/LithnetRMA.Tests/Binding.Tests.ps1
@@ -54,13 +54,26 @@ Describe 'Cmdlet parameter binding (issue #45)' {
             $template | Should -Not -BeNullOrEmpty -Because 'a wrapped ID must be unwrapped, not silently dropped into a null result'
         }
 
-        It 'Remove-Resource does not silently skip a PSObject-wrapped ID' -Tag 'RequiresDelete' {
-            # The bug: a wrapped GUID fails every 'as' cast and is dropped, so DeleteResources is
-            # called with an empty list and nothing happens - no error. Proving the positive
-            # (the delete actually occurs) needs an account with delete rights and a throwaway
-            # object, which belongs in the functional tier (C5). Skipped here so the read-only
-            # binding run stays deterministic, but kept visible so the gap is not forgotten.
-            Set-ItResult -Skipped -Because 'needs an account with delete rights + a throwaway object; covered by the functional tier'
+        It 'Remove-Resource deletes the object when the ID is PSObject-wrapped' {
+            # The bug: a wrapped GUID failed every 'as' cast and was dropped, so DeleteResources
+            # was called with an empty list and the delete silently never happened - no error,
+            # wrong result. Prove the positive: create a throwaway object, delete it via a
+            # wrapped ID, and confirm it is actually gone. The suite connects with an account
+            # that owns the _unitTestObject data (the bootstrap deletes all instances), so
+            # delete rights are a given here.
+            $marker = "rmwrap_$([guid]::NewGuid().ToString('N'))"
+            $resource = New-Resource -ObjectType '_unitTestObject'
+            $resource.ut_svstring = $marker
+            Save-Resource $resource
+
+            @(Search-Resources -XPath "/_unitTestObject[ut_svstring = '$marker']" -AttributesToGet ObjectID).Count |
+                Should -Be 1 -Because 'the throwaway object must exist before the delete'
+
+            $wrappedId = [psobject]::AsPSObject($resource.ObjectID)
+            Remove-Resource -ID $wrappedId
+
+            @(Search-Resources -XPath "/_unitTestObject[ut_svstring = '$marker']" -AttributesToGet ObjectID).Count |
+                Should -Be 0 -Because 'a wrapped ID must be unwrapped and the delete performed, not silently dropped'
         }
     }
 }

--- a/test/LithnetRMA.Tests/Binding.Tests.ps1
+++ b/test/LithnetRMA.Tests/Binding.Tests.ps1
@@ -1,0 +1,66 @@
+<#
+    Parameter-binding tests for the cmdlets reported in GitHub issue #45 and the two latent
+    cmdlets with the same defect.
+
+    Root cause: these cmdlets declare parameters as [object] / [object[]] and then either hard-cast
+    to a client type or type-test with 'as'. PowerShell wraps a value passed to an [object] parameter
+    in a PSObject (there is no target type to coerce to), so the hard cast throws and the 'as' test
+    silently misses. A test that calls the cmdlet class directly in C# cannot see this - the wrapper
+    only exists when the real PowerShell binder runs, which is why these tests are in Pester.
+
+    These are written to FAIL against the current code and PASS once the cmdlets declare real
+    parameter types / unwrap the PSObject. They connect to the test MIM (via _Bootstrap) because
+    New-XPathQuery validates the attribute name against the live schema.
+#>
+
+BeforeAll {
+    . $PSScriptRoot/_Bootstrap.ps1
+}
+
+Describe 'Cmdlet parameter binding (issue #45)' {
+
+    Context 'Reported: hard cast to a client type throws InvalidCastException' {
+
+        It 'New-XPathExpression accepts an XPathQuery held in a variable' {
+            $query = New-XPathQuery -AttributeName AccountName -Operator Equals -Value 'someone'
+            { New-XPathExpression -ObjectType Person -QueryObject $query } |
+                Should -Not -Throw
+        }
+
+        It 'New-XPathExpression accepts an XPathQuery from the pipeline' {
+            {
+                New-XPathQuery -AttributeName AccountName -Operator Equals -Value 'someone' |
+                    New-XPathExpression -ObjectType Person
+            } | Should -Not -Throw
+        }
+
+        It 'New-XPathQueryGroup accepts an untyped array of queries' {
+            $q1 = New-XPathQuery -AttributeName AccountName -Operator Equals -Value 'a'
+            $q2 = New-XPathQuery -AttributeName AccountName -Operator Equals -Value 'b'
+            { New-XPathQueryGroup -Operator Or -Queries ($q1, $q2) } |
+                Should -Not -Throw
+        }
+    }
+
+    Context 'Latent: PSObject-wrapped value is silently dropped (no error, wrong result)' {
+
+        It 'New-ResourceUpdateTemplate returns a template when the ID is PSObject-wrapped' {
+            $person = Search-Resources -XPath '/Person' -AttributesToGet ObjectID -MaxResults 1
+            $person | Should -Not -BeNullOrEmpty -Because 'the lab MIM must contain at least one Person'
+
+            $wrappedId = [psobject]::AsPSObject($person.ObjectID)
+            $template = New-ResourceUpdateTemplate -ObjectType Person -ID $wrappedId
+
+            $template | Should -Not -BeNullOrEmpty -Because 'a wrapped ID must be unwrapped, not silently dropped into a null result'
+        }
+
+        It 'Remove-Resource does not silently skip a PSObject-wrapped ID' -Tag 'RequiresDelete' {
+            # The bug: a wrapped GUID fails every 'as' cast and is dropped, so DeleteResources is
+            # called with an empty list and nothing happens - no error. Proving the positive
+            # (the delete actually occurs) needs an account with delete rights and a throwaway
+            # object, which belongs in the functional tier (C5). Skipped here so the read-only
+            # binding run stays deterministic, but kept visible so the gap is not forgotten.
+            Set-ItResult -Skipped -Because 'needs an account with delete rights + a throwaway object; covered by the functional tier'
+        }
+    }
+}

--- a/test/LithnetRMA.Tests/Build-TestModule.ps1
+++ b/test/LithnetRMA.Tests/Build-TestModule.ps1
@@ -1,0 +1,65 @@
+<#
+.SYNOPSIS
+    Builds the LithnetRMA binary module from source and stages it into the dual-edition
+    folder layout that LithnetRMA.psm1 expects (coreclr\ for PowerShell 7, desktop\ for
+    Windows PowerShell 5.1), then returns the path to the staged module manifest.
+
+.DESCRIPTION
+    The Pester suite must exercise the module as it actually ships - a script module
+    (LithnetRMA.psm1) that loads the binary from coreclr\ or desktop\ depending on the
+    running edition. The flat dotnet build output does not have that shape, so this helper
+    assembles it. Building from source (not the published package) is deliberate: the whole
+    point of the suite is to validate fixes to this source tree.
+
+.OUTPUTS
+    The full path to the staged LithnetRMA.psd1.
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('Debug', 'Release')]
+    [string] $Configuration = 'Debug'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Resolve-Path ([System.IO.Path]::Combine($PSScriptRoot, '..', '..'))
+$project = Join-Path $repoRoot 'src\Lithnet.ResourceManagement.Automation\Lithnet.ResourceManagement.Automation.csproj'
+$projectDir = Split-Path $project -Parent
+$stageRoot = Join-Path $PSScriptRoot '.module'
+$moduleDir = Join-Path $stageRoot 'LithnetRMA'
+
+# Map each target framework to the module subfolder the .psm1 loads it from.
+$editions = @(
+    [pscustomobject]@{ Tfm = 'net8.0'; SubDir = 'coreclr' }
+    [pscustomobject]@{ Tfm = 'net48';  SubDir = 'desktop' }
+)
+
+foreach ($edition in $editions)
+{
+    Write-Verbose "Building $($edition.Tfm)"
+    & dotnet build $project -c $Configuration -f $edition.Tfm -v quiet | Out-Null
+    if ($LASTEXITCODE -ne 0)
+    {
+        throw "dotnet build failed for $($edition.Tfm)"
+    }
+}
+
+if (Test-Path $moduleDir)
+{
+    Remove-Item $moduleDir -Recurse -Force
+}
+New-Item -ItemType Directory -Path $moduleDir -Force | Out-Null
+
+# The manifest and script module live at the module root.
+Copy-Item (Join-Path $projectDir 'LithnetRMA.psd1') $moduleDir -Force
+Copy-Item (Join-Path $projectDir 'LithnetRMA.psm1') $moduleDir -Force
+
+foreach ($edition in $editions)
+{
+    $source = Join-Path $projectDir "bin\$Configuration\$($edition.Tfm)"
+    $target = Join-Path $moduleDir $edition.SubDir
+    New-Item -ItemType Directory -Path $target -Force | Out-Null
+    Copy-Item (Join-Path $source '*') $target -Recurse -Force
+}
+
+Join-Path $moduleDir 'LithnetRMA.psd1'

--- a/test/LithnetRMA.Tests/Connectivity.Tests.ps1
+++ b/test/LithnetRMA.Tests/Connectivity.Tests.ps1
@@ -1,0 +1,21 @@
+<#
+    Proves the test platform itself works: the freshly built module imports, connects to the test
+    MIM service at the same endpoint the resourcemanagement-client unit tests use, and can read.
+    If this fails, a red result elsewhere is a platform problem, not a code defect.
+#>
+
+BeforeAll {
+    . $PSScriptRoot/_Bootstrap.ps1
+}
+
+Describe 'Test platform' {
+
+    It 'exports the expected cmdlet surface' {
+        (Get-Command -Module LithnetRMA).Count | Should -BeGreaterThan 0
+    }
+
+    It 'connects to the MIM service and reads a Person' {
+        $result = Search-Resources -XPath '/Person' -AttributesToGet DisplayName -MaxResults 1
+        @($result).Count | Should -BeGreaterThan 0
+    }
+}

--- a/test/LithnetRMA.Tests/Create.Tests.ps1
+++ b/test/LithnetRMA.Tests/Create.Tests.ps1
@@ -1,0 +1,65 @@
+<#
+    Cmdlet equivalent of the client unit tests' CreateTests.cs. Exercises New-Resource + Save-Resource
+    and asserts what the cmdlet surface exposes: a created resource gets a real ObjectID, its data
+    round-trips through Get-Resource, and a composite (multi-object) save works.
+#>
+
+BeforeAll {
+    . $PSScriptRoot/_Bootstrap.ps1
+    $script:data = Get-TestData
+    $script:refs = Initialize-ReferenceObjects
+}
+
+Describe 'New-Resource / Save-Resource' {
+
+    BeforeEach {
+        $script:created = [System.Collections.Generic.List[object]]::new()
+    }
+
+    AfterEach {
+        foreach ($id in $script:created) { $id | Remove-TestResource }
+    }
+
+    It 'creates a resource with populated data and round-trips it through Get-Resource' {
+        $resource = New-TestResource
+        Set-TestUserData -Resource $resource -Data $script:data -References $script:refs
+        Save-Resource $resource
+
+        $resource.ObjectID | Should -Not -BeNullOrEmpty
+        $script:created.Add($resource.ObjectID)
+
+        $fetched = Get-Resource -ID $resource.ObjectID
+        Assert-TestUserData -Resource $fetched -Data $script:data -References $script:refs
+    }
+
+    It 'creates a resource carrying only an account name' {
+        $account = "create-$([Guid]::NewGuid().ToString('N'))"
+        $resource = New-TestResource -AccountName $account
+        Save-Resource $resource
+        $script:created.Add($resource.ObjectID)
+
+        $fetched = Get-Resource -ObjectType _unitTestObject -AttributeName AccountName -AttributeValue $account
+        $fetched | Should -Not -BeNullOrEmpty
+        $fetched.ObjectID | Should -Be $resource.ObjectID
+    }
+
+    It 'creates multiple resources in a single composite save' {
+        $accounts = 1..5 | ForEach-Object { "composite-$([Guid]::NewGuid().ToString('N'))" }
+        $resources = foreach ($account in $accounts)
+        {
+            $r = New-TestResource -AccountName $account
+            Set-TestUserData -Resource $r -Data $script:data -References $script:refs
+            $r
+        }
+
+        Save-Resource $resources
+
+        foreach ($r in $resources)
+        {
+            $r.ObjectID | Should -Not -BeNullOrEmpty
+            $script:created.Add($r.ObjectID)
+            $fetched = Get-Resource -ID $r.ObjectID
+            Assert-TestUserData -Resource $fetched -Data $script:data -References $script:refs
+        }
+    }
+}

--- a/test/LithnetRMA.Tests/Delete.Tests.ps1
+++ b/test/LithnetRMA.Tests/Delete.Tests.ps1
@@ -1,0 +1,129 @@
+<#
+    Cmdlet equivalent of the client unit tests' DeleteTests.cs. Exercises Remove-Resource across both
+    of its parameter sets: -ID (single value or array, accepting the UniqueIdentifier / Guid / string
+    forms the cmdlet switches on) and -ResourceObjects (pipeline). The only cmdlet-observable outcome
+    of a delete is asserted: the object has a real ObjectID after Save-Resource, and once removed a
+    Get-Resource -ID for it throws "not found".
+
+    Two unit tests are intentionally not ported: DeleteEmptyListResource and
+    DeleteEmptyListUniqueIdentifier. They assert the client library tolerates being handed an empty
+    collection to delete, which is a client-API concern. Remove-Resource's -ID and -ResourceObjects
+    parameters are both Mandatory, so "delete nothing" has no well-defined, observable cmdlet contract
+    to assert against.
+#>
+
+BeforeAll {
+    . $PSScriptRoot/_Bootstrap.ps1
+    $script:data = Get-TestData
+    $script:refs = Initialize-ReferenceObjects
+}
+
+Describe 'Remove-Resource' {
+
+    BeforeEach {
+        $script:created = [System.Collections.Generic.List[object]]::new()
+    }
+
+    AfterEach {
+        # Safety net: these tests delete their own objects, but best-effort remove any that survived
+        # a failed assertion. Remove-TestResource swallows 'not found', so re-deleting is harmless.
+        foreach ($id in $script:created) { $id | Remove-TestResource }
+    }
+
+    It 'deletes a resource by its ObjectID (UniqueIdentifier form)' {
+        # Mirrors DeleteByID: delete using the ObjectID value as returned after save.
+        $resource = New-TestResource -AccountName "delete-$([Guid]::NewGuid().ToString('N'))"
+        Save-Resource $resource
+        $resource.ObjectID | Should -Not -BeNullOrEmpty
+        $id = $resource.ObjectID
+        $script:created.Add($id)
+
+        Remove-Resource -ID $id
+
+        { Get-Resource -ID $id } | Should -Throw
+    }
+
+    It 'deletes a resource by its ObjectID given as a Guid' {
+        # Mirrors DeleteByGuid: the cmdlet's -ID switch accepts a raw Guid.
+        $resource = New-TestResource -AccountName "delete-$([Guid]::NewGuid().ToString('N'))"
+        Save-Resource $resource
+        $resource.ObjectID | Should -Not -BeNullOrEmpty
+        $script:created.Add($resource.ObjectID)
+
+        Remove-Resource -ID $resource.ObjectID.GetGuid()
+
+        { Get-Resource -ID $resource.ObjectID } | Should -Throw
+    }
+
+    It 'deletes a resource by its ObjectID given as a string' {
+        # Mirrors DeleteByString: the cmdlet's -ID switch accepts the string form of the identifier.
+        $resource = New-TestResource -AccountName "delete-$([Guid]::NewGuid().ToString('N'))"
+        Save-Resource $resource
+        $resource.ObjectID | Should -Not -BeNullOrEmpty
+        $script:created.Add($resource.ObjectID)
+
+        Remove-Resource -ID $resource.ObjectID.Value
+
+        { Get-Resource -ID $resource.ObjectID } | Should -Throw
+    }
+
+    It 'deletes a resource piped as a resource object' {
+        # Mirrors DeleteByObject: pipe the RmaObject to bind the -ResourceObjects parameter set.
+        $resource = New-TestResource -AccountName "delete-$([Guid]::NewGuid().ToString('N'))"
+        Save-Resource $resource
+        $resource.ObjectID | Should -Not -BeNullOrEmpty
+        $script:created.Add($resource.ObjectID)
+
+        $resource | Remove-Resource
+
+        { Get-Resource -ID $resource.ObjectID } | Should -Throw
+    }
+
+    It 'throws when deleting a resource that does not exist' {
+        # Mirrors DeleteByStringNonExistant: deleting an id that resolves to nothing raises an error
+        # (the service returns permission-denied for a non-existent object). The observable contract
+        # at the cmdlet surface is simply that Remove-Resource throws.
+        $missing = 'f970bdf5-7b41-4618-82e6-ff16d34d2e41'
+
+        { Remove-Resource -ID $missing } | Should -Throw
+    }
+
+    It 'deletes multiple resources in a single call by an array of IDs' {
+        # Mirrors CompositeDeleteByIDTest: pass an array of identifiers to -ID.
+        $resources = 1..3 | ForEach-Object { New-TestResource -AccountName "delete-$([Guid]::NewGuid().ToString('N'))" }
+        Save-Resource $resources
+
+        $ids = foreach ($r in $resources)
+        {
+            $r.ObjectID | Should -Not -BeNullOrEmpty
+            $script:created.Add($r.ObjectID)
+            $r.ObjectID
+        }
+
+        Remove-Resource -ID $ids
+
+        foreach ($id in $ids)
+        {
+            { Get-Resource -ID $id } | Should -Throw
+        }
+    }
+
+    It 'deletes multiple resources piped as resource objects' {
+        # Mirrors CompositeDeleteByObjectTest: pipe several RmaObjects through the -ResourceObjects set.
+        $resources = 1..3 | ForEach-Object { New-TestResource -AccountName "delete-$([Guid]::NewGuid().ToString('N'))" }
+        Save-Resource $resources
+
+        foreach ($r in $resources)
+        {
+            $r.ObjectID | Should -Not -BeNullOrEmpty
+            $script:created.Add($r.ObjectID)
+        }
+
+        $resources | Remove-Resource
+
+        foreach ($r in $resources)
+        {
+            { Get-Resource -ID $r.ObjectID } | Should -Throw
+        }
+    }
+}

--- a/test/LithnetRMA.Tests/Get.Tests.ps1
+++ b/test/LithnetRMA.Tests/Get.Tests.ps1
@@ -1,0 +1,197 @@
+<#
+    Cmdlet equivalent of the client unit tests' GetTests.cs. Exercises Get-Resource across its three
+    parameter sets - by ID (-ID), by a single key (-ObjectType/-AttributeName/-AttributeValue) and by
+    multiple keys (-ObjectType/-AttributeValuePairs) - plus attribute projection (-AttributesToGet)
+    and the not-found / too-many-results failure paths.
+
+    Only cmdlet-observable behaviour is asserted. The C# tests' internal-state checks (IsPlaceHolder
+    in the finally blocks) are replaced by AfterEach cleanup that deletes every object created by ID.
+#>
+
+BeforeAll {
+    . $PSScriptRoot/_Bootstrap.ps1
+    $script:data = Get-TestData
+    $script:refs = Initialize-ReferenceObjects
+}
+
+Describe 'Get-Resource' {
+
+    BeforeEach {
+        $script:created = [System.Collections.Generic.List[object]]::new()
+    }
+
+    AfterEach {
+        foreach ($id in $script:created) { $id | Remove-TestResource }
+    }
+
+    Context 'By ID' {
+
+        It 'gets a resource by its ObjectID and round-trips all attributes' {
+            $resource = New-TestResource
+            Set-TestUserData -Resource $resource -Data $script:data -References $script:refs
+            Save-Resource $resource
+            $script:created.Add($resource.ObjectID)
+
+            $fetched = Get-Resource -ID $resource.ObjectID
+            Assert-TestUserData -Resource $fetched -Data $script:data -References $script:refs
+        }
+
+        It 'gets a resource by its ObjectID in string form' {
+            $resource = New-TestResource
+            Set-TestUserData -Resource $resource -Data $script:data -References $script:refs
+            Save-Resource $resource
+            $script:created.Add($resource.ObjectID)
+
+            $fetched = Get-Resource -ID $resource.ObjectID.Value
+            Assert-TestUserData -Resource $fetched -Data $script:data -References $script:refs
+        }
+
+        It 'gets a resource by its ObjectID in Guid form' {
+            $resource = New-TestResource
+            Set-TestUserData -Resource $resource -Data $script:data -References $script:refs
+            Save-Resource $resource
+            $script:created.Add($resource.ObjectID)
+
+            $fetched = Get-Resource -ID $resource.ObjectID.GetGuid()
+            Assert-TestUserData -Resource $fetched -Data $script:data -References $script:refs
+        }
+
+        It 'returns only the requested attributes when -AttributesToGet is used' {
+            $a = $script:data.Attr
+
+            $resource = New-TestResource
+            Set-TestUserData -Resource $resource -Data $script:data -References $script:refs
+            Save-Resource $resource
+            $script:created.Add($resource.ObjectID)
+
+            $fetched = Get-Resource -ID $resource.ObjectID -AttributesToGet @($a.BooleanSV, $a.StringSV, $a.ReferenceMV)
+
+            # requested attributes are present with the expected values
+            $fetched.($a.BooleanSV) | Should -Be $script:data.BooleanTrue
+            $fetched.($a.StringSV)  | Should -Be $script:data.String1
+            (@($fetched.($a.ReferenceMV)) | ForEach-Object { "$_" } | Sort-Object) |
+                Should -Be (@($script:refs.Ref1MV) | ForEach-Object { "$_" } | Sort-Object)
+
+            # attributes that were not requested come back null
+            $fetched.($a.IntegerSV) | Should -BeNullOrEmpty
+            $fetched.($a.TextSV)    | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'By a single key attribute' {
+
+        It 'gets a resource by AccountName and round-trips all attributes' {
+            $a = $script:data.Attr
+            $account = "get-$([Guid]::NewGuid().ToString('N'))"
+
+            $resource = New-TestResource -AccountName $account
+            Set-TestUserData -Resource $resource -Data $script:data -References $script:refs
+            Save-Resource $resource
+            $script:created.Add($resource.ObjectID)
+
+            $fetched = Get-Resource -ObjectType $script:data.UnitTestObjectType -AttributeName $a.AccountName -AttributeValue $account
+            Assert-TestUserData -Resource $fetched -Data $script:data -References $script:refs
+        }
+
+        It 'gets a resource by AccountName with only the requested attributes' {
+            $a = $script:data.Attr
+            $account = "get-$([Guid]::NewGuid().ToString('N'))"
+
+            $resource = New-TestResource -AccountName $account
+            Set-TestUserData -Resource $resource -Data $script:data -References $script:refs
+            Save-Resource $resource
+            $script:created.Add($resource.ObjectID)
+
+            $fetched = Get-Resource -ObjectType $script:data.UnitTestObjectType -AttributeName $a.AccountName -AttributeValue $account `
+                -AttributesToGet @($a.AccountName, $a.BooleanSV, $a.StringSV, $a.ReferenceMV)
+
+            $fetched.($a.AccountName) | Should -Be $account
+            $fetched.($a.BooleanSV)   | Should -Be $script:data.BooleanTrue
+            $fetched.($a.StringSV)    | Should -Be $script:data.String1
+            (@($fetched.($a.ReferenceMV)) | ForEach-Object { "$_" } | Sort-Object) |
+                Should -Be (@($script:refs.Ref1MV) | ForEach-Object { "$_" } | Sort-Object)
+
+            $fetched.($a.IntegerSV) | Should -BeNullOrEmpty
+            $fetched.($a.TextSV)    | Should -BeNullOrEmpty
+        }
+
+        It 'throws when a single-key lookup matches more than one resource' {
+            $a = $script:data.Attr
+
+            $r1 = New-TestResource
+            Set-TestUserData -Resource $r1 -Data $script:data -References $script:refs
+            Save-Resource $r1
+            $script:created.Add($r1.ObjectID)
+
+            $r2 = New-TestResource
+            Set-TestUserData -Resource $r2 -Data $script:data -References $script:refs
+            Save-Resource $r2
+            $script:created.Add($r2.ObjectID)
+
+            # both resources share the same ut_svstring value, so a lookup on it is ambiguous
+            { Get-Resource -ObjectType $script:data.UnitTestObjectType -AttributeName $a.StringSV -AttributeValue $script:data.String1 } |
+                Should -Throw
+        }
+
+        It 'throws when a single-key lookup finds no matching resource' {
+            $a = $script:data.Attr
+
+            # the client returns null on no match; the cmdlet turns that into a not-found terminating error
+            { Get-Resource -ObjectType $script:data.UnitTestObjectType -AttributeName $a.StringSV -AttributeValue ([Guid]::NewGuid().ToString()) } |
+                Should -Throw -ExpectedMessage '*not found*'
+        }
+    }
+
+    Context 'By multiple key attributes' {
+
+        It 'gets a resource by AccountName + string key and round-trips all attributes' {
+            $a = $script:data.Attr
+            $account = "get-$([Guid]::NewGuid().ToString('N'))"
+
+            $resource = New-TestResource -AccountName $account
+            Set-TestUserData -Resource $resource -Data $script:data -References $script:refs
+            Save-Resource $resource
+            $script:created.Add($resource.ObjectID)
+
+            $keys = @{}
+            $keys[$a.AccountName] = $account
+            $keys[$a.StringSV] = $script:data.String1
+
+            $fetched = Get-Resource -ObjectType $script:data.UnitTestObjectType -AttributeValuePairs $keys
+            Assert-TestUserData -Resource $fetched -Data $script:data -References $script:refs
+        }
+
+        It 'gets a resource by multiple keys with only the requested attributes' {
+            $a = $script:data.Attr
+            $account = "get-$([Guid]::NewGuid().ToString('N'))"
+
+            $resource = New-TestResource -AccountName $account
+            Set-TestUserData -Resource $resource -Data $script:data -References $script:refs
+            Save-Resource $resource
+            $script:created.Add($resource.ObjectID)
+
+            $keys = @{}
+            $keys[$a.AccountName] = $account
+            $keys[$a.StringSV] = $script:data.String1
+
+            $fetched = Get-Resource -ObjectType $script:data.UnitTestObjectType -AttributeValuePairs $keys `
+                -AttributesToGet @($a.AccountName, $a.BooleanSV, $a.StringSV, $a.ReferenceMV)
+
+            $fetched.($a.AccountName) | Should -Be $account
+            $fetched.($a.BooleanSV)   | Should -Be $script:data.BooleanTrue
+            $fetched.($a.StringSV)    | Should -Be $script:data.String1
+            (@($fetched.($a.ReferenceMV)) | ForEach-Object { "$_" } | Sort-Object) |
+                Should -Be (@($script:refs.Ref1MV) | ForEach-Object { "$_" } | Sort-Object)
+
+            $fetched.($a.IntegerSV) | Should -BeNullOrEmpty
+            $fetched.($a.TextSV)    | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Not found' {
+
+        It 'throws when getting a non-existent object by ID' {
+            { Get-Resource -ID ([Guid]::NewGuid()) } | Should -Throw -ExpectedMessage '*not found*'
+        }
+    }
+}

--- a/test/LithnetRMA.Tests/Invoke-Tests.ps1
+++ b/test/LithnetRMA.Tests/Invoke-Tests.ps1
@@ -1,0 +1,50 @@
+<#
+.SYNOPSIS
+    Builds and stages the LithnetRMA module, then runs the Pester suite against the test MIM.
+
+.DESCRIPTION
+    The single entry point for the suite. Builds the module from source (so fixes are what gets
+    tested), stages it into the dual-edition layout, points the suite at it via environment
+    variable, and runs Pester 5. Run under both pwsh (PowerShell 7) and powershell (Windows
+    PowerShell 5.1) to cover both editions - the #45 defects are edition-sensitive.
+
+.EXAMPLE
+    pwsh -File ./test/LithnetRMA.Tests/Invoke-Tests.ps1
+    powershell -File ./test/LithnetRMA.Tests/Invoke-Tests.ps1 -OutputXml ./test-results-desktop.xml
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('Debug', 'Release')]
+    [string] $Configuration = 'Debug',
+
+    [string] $BaseAddress = 'fimsvc',
+
+    [string] $ServicePrincipalName = 'FIMService/fimsvc',
+
+    [ValidateSet('Auto', 'LocalProxy', 'RemoteProxy', 'DirectNetTcp', 'DirectWsHttp')]
+    [string] $ConnectionMode = 'LocalProxy',
+
+    [string] $OutputXml
+)
+
+$ErrorActionPreference = 'Stop'
+
+$env:LITHNETRMA_MODULE_PATH = & (Join-Path $PSScriptRoot 'Build-TestModule.ps1') -Configuration $Configuration
+$env:LITHNETRMA_TEST_BASEADDRESS = $BaseAddress
+$env:LITHNETRMA_TEST_SPN = $ServicePrincipalName
+$env:LITHNETRMA_TEST_MODE = $ConnectionMode
+
+Import-Module Pester -MinimumVersion 5.0
+
+$config = New-PesterConfiguration
+$config.Run.Path = $PSScriptRoot
+$config.Output.Verbosity = 'Detailed'
+
+if ($OutputXml)
+{
+    $config.TestResult.Enabled = $true
+    $config.TestResult.OutputFormat = 'NUnitXml'
+    $config.TestResult.OutputPath = $OutputXml
+}
+
+Invoke-Pester -Configuration $config

--- a/test/LithnetRMA.Tests/LithnetRMA.TestSupport.psm1
+++ b/test/LithnetRMA.Tests/LithnetRMA.TestSupport.psm1
@@ -1,0 +1,377 @@
+<#
+    Shared test support for the LithnetRMA Pester suite. This is the PowerShell equivalent of the
+    resourcemanagement-client unit tests' Constants.cs, UnitTestHelper.cs and the schema/reference
+    bootstrap in Setup.cs. It drives the same _unitTestObject schema and the same test data, so the
+    Pester suite mirrors the client unit tests case-for-case at the cmdlet surface.
+
+    Like the client unit tests' Setup.cs, this module does NOT assume the _unitTestObject schema
+    exists: Initialize-TestSchema checks for the object type, its ut_* attributes and their bindings
+    and creates any that are missing (create rights are assumed), then refreshes the client schema.
+#>
+
+# --- Attribute name constants (mirror Constants.cs) -----------------------------------------------
+
+$script:UnitTestObjectType = '_unitTestObject'
+$script:Attr = @{
+    StringSV    = 'ut_svstring'
+    StringMV    = 'ut_mvstring'
+    IntegerSV   = 'ut_svinteger'
+    IntegerMV   = 'ut_mvinteger'
+    ReferenceSV = 'ut_svreference'
+    ReferenceMV = 'ut_mvreference'
+    TextSV      = 'ut_svtext'
+    TextMV      = 'ut_mvtext'
+    DateTimeSV  = 'ut_svdatetime'
+    DateTimeMV  = 'ut_mvdatetime'
+    BinarySV    = 'ut_svbinary'
+    BinaryMV    = 'ut_mvbinary'
+    BooleanSV   = 'ut_svboolean'
+    AccountName = 'AccountName'
+}
+
+function ConvertTo-UtcSeconds
+{
+    <# Normalises a datetime returned by MIM (which may come back as local time with an offset) to a
+       UTC, second-precision string so comparisons are instant-based, not representation-based. #>
+    param([Parameter(Mandatory)] $Value)
+    return ([datetime]$Value).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss')
+}
+
+function Get-TestData
+{
+    <# Returns a hashtable of round-trippable test data mirroring Constants.cs. DateTimes are
+       truncated to whole seconds because the MIM service stores second precision. #>
+    $now = [DateTime]::UtcNow
+    $trunc = { param($d) [DateTime]::new($d.Year, $d.Month, $d.Day, $d.Hour, $d.Minute, $d.Second, [DateTimeKind]::Utc) }
+
+    return @{
+        Attr = $script:Attr
+        UnitTestObjectType = $script:UnitTestObjectType
+
+        String1   = 'testString1'
+        String1MV = @('testString4', 'testString5', 'testString6')
+        Integer1  = [long]4
+        Integer1MV = @([long]13, [long]14, [long]15)
+        Text1     = 'testText1'
+        Text1MV   = @('testText4', 'testText5', 'testText6')
+        BooleanTrue = $true
+        Binary1   = [byte[]]@(0, 1, 2, 3)
+        Binary1MV = @(, [byte[]]@(12, 13, 14, 15)) + @(, [byte[]]@(16, 17, 18, 19)) + @(, [byte[]]@(20, 21, 22, 23))
+        DateTime1 = & $trunc $now
+        DateTime1MV = @((& $trunc $now.AddDays(3)), (& $trunc $now.AddDays(4)), (& $trunc $now.AddDays(5)))
+    }
+}
+
+# --- Connection (mirrors the unit tests' appsettings.json / App.config) ---------------------------
+
+function Connect-TestClient
+{
+    <#
+        The SPN differs by connection mode because it authenticates a different service. Direct and
+        LocalProxy connections authenticate the MIM Service itself (FIMService/..., held by the MIM
+        service account). A RemoteProxy connection authenticates the proxy service, which runs as
+        NT AUTHORITY\NetworkService, so its SPN belongs to the host computer account (host/...).
+        For RemoteProxy, LITHNETRMA_TEST_PROXY_SPN overrides; when unset, no SPN is passed so the
+        client's own default applies - the same configuration a customer gets out of the box.
+    #>
+    param(
+        [string] $BaseAddress = $(if ($env:LITHNETRMA_TEST_BASEADDRESS) { $env:LITHNETRMA_TEST_BASEADDRESS } else { 'fimsvc' }),
+        [string] $ServicePrincipalName = $(if ($env:LITHNETRMA_TEST_SPN) { $env:LITHNETRMA_TEST_SPN } else { 'FIMService/fimsvc' }),
+        [string] $ConnectionMode = $(if ($env:LITHNETRMA_TEST_MODE) { $env:LITHNETRMA_TEST_MODE } else { 'LocalProxy' }),
+        [pscredential] $Credential
+    )
+
+    $arguments = @{
+        BaseAddress = $BaseAddress
+        ConnectionMode = $ConnectionMode
+    }
+
+    if ($ConnectionMode -eq 'RemoteProxy')
+    {
+        if ($env:LITHNETRMA_TEST_PROXY_SPN)
+        {
+            $arguments.ServicePrincipalName = $env:LITHNETRMA_TEST_PROXY_SPN
+        }
+    }
+    else
+    {
+        $arguments.ServicePrincipalName = $ServicePrincipalName
+    }
+
+    if ($Credential)
+    {
+        $arguments.Credentials = $Credential
+    }
+
+    Set-ResourceManagementClient @arguments
+}
+
+# --- Schema bootstrap (mirror Setup.cs PrepareRMSForUnitTests) -------------------------------------
+
+$script:SchemaInitialized = $false
+
+function Get-ResourceByKeyOrNull
+{
+    param([string] $ObjectType, [string] $AttributeName, $AttributeValue)
+    try
+    {
+        return Get-Resource -ObjectType $ObjectType -AttributeName $AttributeName -AttributeValue $AttributeValue
+    }
+    catch
+    {
+        return $null
+    }
+}
+
+function New-SchemaObjectTypeIfMissing
+{
+    $existing = Get-ResourceByKeyOrNull -ObjectType ObjectTypeDescription -AttributeName Name -AttributeValue $script:UnitTestObjectType
+    if ($existing) { return $existing }
+
+    $r = New-Resource -ObjectType ObjectTypeDescription
+    $r.Name = $script:UnitTestObjectType
+    $r.DisplayName = $script:UnitTestObjectType
+    Save-Resource $r
+    $script:SchemaChanged = $true
+    return $r
+}
+
+function New-SchemaAttributeIfMissing
+{
+    param([string] $Name, [string] $DataType, [bool] $Multivalued)
+
+    $existing = Get-ResourceByKeyOrNull -ObjectType AttributeTypeDescription -AttributeName Name -AttributeValue $Name
+    if ($existing) { return $existing }
+
+    $r = New-Resource -ObjectType AttributeTypeDescription
+    $r.Name = $Name
+    $r.DisplayName = $Name
+    $r.Multivalued = $Multivalued
+    $r.DataType = $DataType
+    Save-Resource $r
+    $script:SchemaChanged = $true
+    return $r
+}
+
+function New-SchemaBindingIfMissing
+{
+    param($ObjectTypeResource, $AttributeResource)
+
+    $existing = $null
+    try
+    {
+        $existing = Get-Resource -ObjectType BindingDescription -AttributeValuePairs @{
+            BoundObjectType    = $ObjectTypeResource.ObjectID
+            BoundAttributeType = $AttributeResource.ObjectID
+        }
+    }
+    catch
+    {
+        $existing = $null
+    }
+
+    if ($existing) { return }
+
+    $r = New-Resource -ObjectType BindingDescription
+    $r.BoundObjectType = $ObjectTypeResource.ObjectID
+    $r.BoundAttributeType = $AttributeResource.ObjectID
+    $r.Required = $false
+    Save-Resource $r
+    $script:SchemaChanged = $true
+}
+
+function Initialize-TestSchema
+{
+    <# Ensures the _unitTestObject type, its ut_* attributes and their bindings exist, creating any
+       that are missing and refreshing the client schema only if something was created. Runs once per
+       process (guarded), mirroring the client unit tests' OneTimeSetUp. #>
+    if ($script:SchemaInitialized) { return }
+    $script:SchemaChanged = $false
+
+    $objectType = New-SchemaObjectTypeIfMissing
+
+    $definitions = @(
+        @{ Name = $script:Attr.StringSV;    DataType = 'String';    Multivalued = $false }
+        @{ Name = $script:Attr.StringMV;    DataType = 'String';    Multivalued = $true  }
+        @{ Name = $script:Attr.IntegerSV;   DataType = 'Integer';   Multivalued = $false }
+        @{ Name = $script:Attr.IntegerMV;   DataType = 'Integer';   Multivalued = $true  }
+        @{ Name = $script:Attr.ReferenceSV; DataType = 'Reference'; Multivalued = $false }
+        @{ Name = $script:Attr.ReferenceMV; DataType = 'Reference'; Multivalued = $true  }
+        @{ Name = $script:Attr.TextSV;      DataType = 'Text';      Multivalued = $false }
+        @{ Name = $script:Attr.TextMV;      DataType = 'Text';      Multivalued = $true  }
+        @{ Name = $script:Attr.DateTimeSV;  DataType = 'DateTime';  Multivalued = $false }
+        @{ Name = $script:Attr.DateTimeMV;  DataType = 'DateTime';  Multivalued = $true  }
+        @{ Name = $script:Attr.BinarySV;    DataType = 'Binary';    Multivalued = $false }
+        @{ Name = $script:Attr.BinaryMV;    DataType = 'Binary';    Multivalued = $true  }
+        @{ Name = $script:Attr.BooleanSV;   DataType = 'Boolean';   Multivalued = $false }
+    )
+
+    $attributes = foreach ($d in $definitions)
+    {
+        New-SchemaAttributeIfMissing -Name $d.Name -DataType $d.DataType -Multivalued $d.Multivalued
+    }
+
+    # AccountName is a built-in MIM attribute; ensure it and bind it, matching Setup.cs.
+    $accountName = New-SchemaAttributeIfMissing -Name $script:Attr.AccountName -DataType 'String' -Multivalued $false
+
+    foreach ($attribute in @($attributes) + @($accountName))
+    {
+        New-SchemaBindingIfMissing -ObjectTypeResource $objectType -AttributeResource $attribute
+    }
+
+    if ($script:SchemaChanged)
+    {
+        Update-ResourceManagementClientSchema
+    }
+
+    $script:SchemaInitialized = $true
+}
+
+# --- Clean slate (mirror UnitTestHelper.DeleteAllTestObjects) ---------------------------------------
+
+function Clear-AllTestObjects
+{
+    <# Deletes every _unitTestObject instance so each run starts from a clean, deterministic slate.
+       Mirrors the client unit tests' reliance on an isolated set of test objects. Returns the count
+       deleted. #>
+    $all = @(Search-Resources -XPath "/$($script:UnitTestObjectType)" -AttributesToGet ObjectID)
+    if ($all.Count -eq 0)
+    {
+        return 0
+    }
+
+    $ids = @($all | ForEach-Object { $_.ObjectID })
+    $batchSize = 200
+    for ($i = 0; $i -lt $ids.Count; $i += $batchSize)
+    {
+        $chunk = $ids[$i..([Math]::Min($i + $batchSize - 1, $ids.Count - 1))]
+        Remove-Resource -ID $chunk
+    }
+
+    return $ids.Count
+}
+
+$script:EnvironmentInitialized = $false
+
+function Initialize-TestEnvironment
+{
+    <# Once-per-process suite setup: ensure the schema exists, then clear all _unitTestObject
+       instances so the run starts clean. Reference objects are (re)created by the tests that need
+       them, after this clean slate. #>
+    if ($script:EnvironmentInitialized)
+    {
+        return
+    }
+
+    Initialize-TestSchema
+    [void](Clear-AllTestObjects)
+    $script:EnvironmentInitialized = $true
+}
+
+# --- Reference objects (mirror Setup.cs CreateReferenceTestObjects) --------------------------------
+
+function Initialize-ReferenceObjects
+{
+    <# Ensures reftest1..reftest6 exist and returns their ObjectIDs plus the two MV groupings used
+       by the reference-attribute tests. Idempotent: reuses existing objects. #>
+    $ids = @{}
+    foreach ($n in 1..6)
+    {
+        $name = "reftest$n"
+        $existing = $null
+        try { $existing = Get-Resource -ObjectType $script:UnitTestObjectType -AttributeName AccountName -AttributeValue $name -AttributesToGet ObjectID } catch { }
+
+        if ($existing)
+        {
+            $ids["Ref$n"] = $existing.ObjectID
+        }
+        else
+        {
+            $r = New-Resource -ObjectType $script:UnitTestObjectType
+            $r.AccountName = $name
+            Save-Resource $r
+            $ids["Ref$n"] = $r.ObjectID
+        }
+    }
+
+    $ids['Ref1MV'] = @($ids['Ref1'], $ids['Ref2'], $ids['Ref3'])
+    $ids['Ref2MV'] = @($ids['Ref4'], $ids['Ref5'], $ids['Ref6'])
+    return $ids
+}
+
+# --- Resource helpers (mirror UnitTestHelper) -----------------------------------------------------
+
+function New-TestResource
+{
+    param([string] $AccountName)
+    $r = New-Resource -ObjectType $script:UnitTestObjectType
+    if ($AccountName)
+    {
+        $r.($script:Attr.AccountName) = $AccountName
+    }
+    return $r
+}
+
+function Set-TestUserData
+{
+    <# Mirrors UnitTestHelper.PopulateTestUserData: sets every attribute type to its test value. #>
+    param(
+        [Parameter(Mandatory)] $Resource,
+        [Parameter(Mandatory)] [hashtable] $Data,
+        [Parameter(Mandatory)] [hashtable] $References
+    )
+    $a = $Data.Attr
+    $Resource.($a.StringSV)    = $Data.String1
+    $Resource.($a.StringMV)    = $Data.String1MV
+    $Resource.($a.IntegerSV)   = $Data.Integer1
+    $Resource.($a.IntegerMV)   = $Data.Integer1MV
+    $Resource.($a.TextSV)      = $Data.Text1
+    $Resource.($a.TextMV)      = $Data.Text1MV
+    $Resource.($a.BooleanSV)   = $Data.BooleanTrue
+    $Resource.($a.BinarySV)    = $Data.Binary1
+    $Resource.($a.BinaryMV)    = $Data.Binary1MV
+    $Resource.($a.DateTimeSV)  = $Data.DateTime1
+    $Resource.($a.DateTimeMV)  = $Data.DateTime1MV
+    $Resource.($a.ReferenceSV) = $References.Ref1
+    $Resource.($a.ReferenceMV) = $References.Ref1MV
+}
+
+function Assert-TestUserData
+{
+    <# Mirrors UnitTestHelper.ValidateTestUserData: asserts every attribute round-tripped. #>
+    param(
+        [Parameter(Mandatory)] $Resource,
+        [Parameter(Mandatory)] [hashtable] $Data,
+        [Parameter(Mandatory)] [hashtable] $References
+    )
+    $a = $Data.Attr
+    $Resource.($a.StringSV)   | Should -Be $Data.String1
+    $Resource.($a.IntegerSV)  | Should -Be $Data.Integer1
+    $Resource.($a.TextSV)     | Should -Be $Data.Text1
+    $Resource.($a.BooleanSV)  | Should -Be $Data.BooleanTrue
+    (ConvertTo-UtcSeconds $Resource.($a.DateTimeSV)) | Should -Be (ConvertTo-UtcSeconds $Data.DateTime1)
+
+    @($Resource.($a.StringMV))  | Should -Be $Data.String1MV
+    @($Resource.($a.IntegerMV)) | Should -Be $Data.Integer1MV
+    @($Resource.($a.TextMV))    | Should -Be $Data.Text1MV
+    @($Resource.($a.DateTimeMV) | ForEach-Object { ConvertTo-UtcSeconds $_ }) | Should -Be @($Data.DateTime1MV | ForEach-Object { ConvertTo-UtcSeconds $_ })
+
+    "$($Resource.($a.ReferenceSV))" | Should -Be "$($References.Ref1)"
+}
+
+# --- Cleanup --------------------------------------------------------------------------------------
+
+function Remove-TestResource
+{
+    <# Deletes by ObjectID, ignoring 'not found' so cleanup is safe to call unconditionally. #>
+    param([Parameter(ValueFromPipeline)] $Id)
+    process
+    {
+        if (-not $Id) { return }
+        try { Remove-Resource -ID $Id } catch { }
+    }
+}
+
+Export-ModuleMember -Function ConvertTo-UtcSeconds, Get-TestData, Connect-TestClient, Initialize-TestSchema,
+    Clear-AllTestObjects, Initialize-TestEnvironment, Initialize-ReferenceObjects, New-TestResource,
+    Set-TestUserData, Assert-TestUserData, Remove-TestResource

--- a/test/LithnetRMA.Tests/Search.Tests.ps1
+++ b/test/LithnetRMA.Tests/Search.Tests.ps1
@@ -1,0 +1,225 @@
+<#
+    Cmdlet equivalent of the client unit tests' SearchTests.cs. Exercises Search-Resources,
+    Search-ResourcesPaged and Get-ResourceCount and asserts what the cmdlet surface exposes:
+    a filter returns exactly the expected objects, results can be sorted, -AttributesToGet
+    controls which attribute values come back, a paged search reports a total and yields pages
+    that can be navigated (including index/page-size jumps), a non-matching filter yields nothing,
+    and an unparseable filter throws.
+
+    The lab MIM holds unrelated objects, so every query is scoped to objects this file created,
+    tagged with a per-run marker stored in ut_svstring. That mirrors the source tests' reliance on
+    the reftest1..6 fixture (which had a known, fixed membership) without depending on shared data.
+#>
+
+BeforeAll {
+    . $PSScriptRoot/_Bootstrap.ps1
+    $script:data = Get-TestData
+    $script:refs = Initialize-ReferenceObjects
+}
+
+Describe 'Search-Resources / Search-ResourcesPaged' {
+
+    BeforeAll {
+        # A set of six objects that all share one marker (for filtering) and carry sortable, unique
+        # AccountNames "<marker>-1".."<marker>-6". These back the search / sort / paged / count cases,
+        # standing in for the source tests' reftest1..6 fixture.
+        $script:sortMarker = "search-$([Guid]::NewGuid().ToString('N'))"
+        $script:sortFilter = "/_unitTestObject[ut_svstring = '$($script:sortMarker)']"
+        $script:sortNames  = 1..6 | ForEach-Object { "$($script:sortMarker)-$_" }
+        $script:sortIds    = [System.Collections.Generic.List[object]]::new()
+
+        foreach ($name in $script:sortNames)
+        {
+            $r = New-Resource -ObjectType _unitTestObject
+            $r.AccountName = $name
+            $r.ut_svstring = $script:sortMarker
+            Save-Resource $r
+            $script:sortIds.Add($r.ObjectID)
+        }
+
+        # A single object with two populated attributes, used to prove -AttributesToGet limits which
+        # attribute values are returned: ut_svstring is the filter/marker, ut_svinteger is the payload
+        # that should only come back when explicitly requested.
+        $script:attrMarker = "search-$([Guid]::NewGuid().ToString('N'))"
+        $script:attrFilter = "/_unitTestObject[ut_svstring = '$($script:attrMarker)']"
+        $script:attrInteger = [long]42
+
+        $a = New-Resource -ObjectType _unitTestObject
+        $a.ut_svstring = $script:attrMarker
+        $a.ut_svinteger = $script:attrInteger
+        Save-Resource $a
+        $script:attrId = $a.ObjectID
+    }
+
+    AfterAll {
+        foreach ($id in $script:sortIds) { $id | Remove-TestResource }
+        $script:attrId | Remove-TestResource
+    }
+
+    Context 'basic search' {
+
+        It 'returns exactly the objects matched by the filter' {
+            # Ports SearchTest(Sync|Async): a query returns the expected result set. The source only
+            # checked that the enumerated count equalled the reported count (an internal-consistency
+            # assertion, dropped here); at the cmdlet surface we assert the returned ObjectIDs are
+            # precisely the ones we created. ObjectID is always returned, even with default attributes.
+            $results = Search-Resources -XPath $script:sortFilter
+            $returnedIds = @($results | ForEach-Object { "$($_.ObjectID)" }) | Sort-Object
+            $expectedIds = @($script:sortIds | ForEach-Object { "$_" }) | Sort-Object
+
+            $returnedIds.Count | Should -Be 6
+            $returnedIds | Should -Be $expectedIds
+        }
+
+        It 'returns nothing for a filter that matches no objects' {
+            # Ports SearchTest(Sync|Async)NoResults: an empty result set for a non-matching filter.
+            $noMatch = "no-such-$([Guid]::NewGuid().ToString('N'))"
+            $results = @(Search-Resources -XPath "/_unitTestObject[ut_svstring = '$noMatch']")
+            $results.Count | Should -Be 0
+        }
+
+        It 'throws when the XPath filter cannot be processed' {
+            # Ports SearchBadFilter: an unparseable filter surfaces as a terminating error
+            # (CannotProcessFilterException in the client) rather than silently returning nothing.
+            { Search-Resources -XPath '!not a filter!' } | Should -Throw
+        }
+    }
+
+    Context 'sorted search' {
+
+        It 'sorts results ascending by the requested attribute' {
+            # Ports SearchTestSyncSortedAsc / SearchTestAsyncSortedAscAsync (the sync/async pair
+            # collapses to one cmdlet call). -AttributesToGet AccountName is required for AccountName
+            # to be returned so the order can be observed.
+            $results = Search-Resources -XPath $script:sortFilter -AttributesToGet AccountName -SortAttributes AccountName
+            $names = @($results | ForEach-Object { $_.AccountName })
+
+            $names.Count | Should -Be 6
+            $names | Should -Be $script:sortNames
+        }
+
+        It 'sorts results descending by the requested attribute' {
+            # Ports SearchTestSyncSortedDesc / SearchTestAsyncSortedDescAsync.
+            $results = Search-Resources -XPath $script:sortFilter -AttributesToGet AccountName -SortAttributes AccountName -Descending
+            $names = @($results | ForEach-Object { $_.AccountName })
+
+            $names.Count | Should -Be 6
+            $names | Should -Be (@($script:sortNames)[5, 4, 3, 2, 1, 0])
+        }
+    }
+
+    Context 'attribute restriction (-AttributesToGet)' {
+
+        It 'returns only the requested attribute values' {
+            # Ports the intent of SearchTestSyncRestrictedAttributeList. The source only re-checked the
+            # count; here we assert the observable effect: a requested attribute carries its value while
+            # an unrequested (but populated) attribute comes back null.
+            $results = @(Search-Resources -XPath $script:attrFilter -AttributesToGet ut_svstring)
+            $results.Count | Should -Be 1
+            $results[0].ut_svstring | Should -Be $script:attrMarker
+            $results[0].ut_svinteger | Should -BeNullOrEmpty
+        }
+
+        It 'returns an attribute value when it is included in the requested list' {
+            $results = @(Search-Resources -XPath $script:attrFilter -AttributesToGet ut_svstring, ut_svinteger)
+            $results.Count | Should -Be 1
+            $results[0].ut_svstring | Should -Be $script:attrMarker
+            $results[0].ut_svinteger | Should -Be $script:attrInteger
+        }
+    }
+
+    Context 'result count (Get-ResourceCount)' {
+
+        It 'reports the number of matching objects' {
+            # Ports SearchTestResultCount.
+            Get-ResourceCount -XPath $script:sortFilter | Should -Be 6
+        }
+    }
+
+    Context 'paged search (Search-ResourcesPaged)' {
+
+        It 'reports the total and pages forward in ascending order, then supports an index/page-size jump' {
+            # Ports SearchTestPagedResultsSortAscAsync (folds in SearchTestPagedSortedAscendingAsync,
+            # which is just the index-jump portion of this same scenario).
+            $pager = Search-ResourcesPaged -XPath $script:sortFilter -AttributesToGet AccountName -SortAttributes AccountName -PageSize 2
+            $pager.TotalCount | Should -Be 6
+
+            $page = @($pager.GetNextPageAsync().GetAwaiter().GetResult())
+            $page.Count | Should -Be 2
+            $pager.HasMoreItems | Should -BeTrue
+            $page[0].AccountName | Should -Be $script:sortNames[0]
+            $page[1].AccountName | Should -Be $script:sortNames[1]
+
+            $page = @($pager.GetNextPageAsync().GetAwaiter().GetResult())
+            $page.Count | Should -Be 2
+            $pager.HasMoreItems | Should -BeTrue
+            $page[0].AccountName | Should -Be $script:sortNames[2]
+            $page[1].AccountName | Should -Be $script:sortNames[3]
+
+            $page = @($pager.GetNextPageAsync().GetAwaiter().GetResult())
+            $page.Count | Should -Be 2
+            $pager.HasMoreItems | Should -BeFalse
+            $page[0].AccountName | Should -Be $script:sortNames[4]
+            $page[1].AccountName | Should -Be $script:sortNames[5]
+
+            # Jump back into the result set and change the page size.
+            $pager.CurrentIndex = 2
+            $pager.PageSize = 4
+            $page = @($pager.GetNextPageAsync().GetAwaiter().GetResult())
+            $page.Count | Should -Be 4
+            $pager.HasMoreItems | Should -BeFalse
+            $page[0].AccountName | Should -Be $script:sortNames[2]
+            $page[1].AccountName | Should -Be $script:sortNames[3]
+            $page[2].AccountName | Should -Be $script:sortNames[4]
+            $page[3].AccountName | Should -Be $script:sortNames[5]
+        }
+
+        It 'reports the total and pages forward in descending order, then supports an index/page-size jump' {
+            # Ports SearchTestPagedResultsSortDescAsync (folds in SearchTestPagedSortedDescendingAsync).
+            $desc = @($script:sortNames)[5, 4, 3, 2, 1, 0]
+
+            $pager = Search-ResourcesPaged -XPath $script:sortFilter -AttributesToGet AccountName -SortAttributes AccountName -Descending -PageSize 2
+            $pager.TotalCount | Should -Be 6
+
+            $page = @($pager.GetNextPageAsync().GetAwaiter().GetResult())
+            $page.Count | Should -Be 2
+            $pager.HasMoreItems | Should -BeTrue
+            $page[0].AccountName | Should -Be $desc[0]
+            $page[1].AccountName | Should -Be $desc[1]
+
+            $page = @($pager.GetNextPageAsync().GetAwaiter().GetResult())
+            $page.Count | Should -Be 2
+            $pager.HasMoreItems | Should -BeTrue
+            $page[0].AccountName | Should -Be $desc[2]
+            $page[1].AccountName | Should -Be $desc[3]
+
+            $page = @($pager.GetNextPageAsync().GetAwaiter().GetResult())
+            $page.Count | Should -Be 2
+            $pager.HasMoreItems | Should -BeFalse
+            $page[0].AccountName | Should -Be $desc[4]
+            $page[1].AccountName | Should -Be $desc[5]
+
+            $pager.CurrentIndex = 2
+            $pager.PageSize = 4
+            $page = @($pager.GetNextPageAsync().GetAwaiter().GetResult())
+            $page.Count | Should -Be 4
+            $pager.HasMoreItems | Should -BeFalse
+            $page[0].AccountName | Should -Be $desc[2]
+            $page[1].AccountName | Should -Be $desc[3]
+            $page[2].AccountName | Should -Be $desc[4]
+            $page[3].AccountName | Should -Be $desc[5]
+        }
+
+        It 'returns the whole result set in a single page when the page size exceeds the total' {
+            # Ports SearchTestPagedDefaultPageAndSizeSortedDescendingAsync.
+            $desc = @($script:sortNames)[5, 4, 3, 2, 1, 0]
+
+            $pager = Search-ResourcesPaged -XPath $script:sortFilter -AttributesToGet AccountName -SortAttributes AccountName -Descending -PageSize 100
+            $pager.TotalCount | Should -Be 6
+
+            $page = @($pager.GetNextPageAsync().GetAwaiter().GetResult())
+            $page.Count | Should -Be 6
+            @($page | ForEach-Object { $_.AccountName }) | Should -Be $desc
+        }
+    }
+}

--- a/test/LithnetRMA.Tests/XPath.Tests.ps1
+++ b/test/LithnetRMA.Tests/XPath.Tests.ps1
@@ -1,0 +1,525 @@
+<#
+    Cmdlet port of the resourcemanagement-client XPath unit tests (XPathExpressionTests.cs,
+    XpathPredicate*Tests.cs). Instead of driving the client's XPathQuery/XPathFilterBuilder
+    types directly, these tests build predicates and groups through the cmdlet surface
+    (New-XPathQuery, New-XPathQueryGroup, New-XPathExpression) and execute them with
+    Search-Resources, then assert that the search returns exactly the objects whose attributes
+    match the predicate under test.
+
+    Scoping: every predicate is combined (via an And group) with a unique per-test marker so a
+    search only ever matches the objects this test created, never the shared _unitTestObject
+    pool. The marker lives in an attribute the predicate under test does not touch: string tests
+    mark with ut_svinteger, every other type marks with ut_svstring.
+
+    These tests assert intended behaviour. New-XPathExpression and New-XPathQueryGroup currently
+    throw an InvalidCastException because of the parameter-binding defect in GitHub issue #45, so
+    every test that routes through them fails until that defect is fixed. That is deliberate: the
+    tests describe the correct behaviour and become the regression guard once #45 is resolved.
+#>
+
+BeforeAll {
+    . $PSScriptRoot/_Bootstrap.ps1
+    $script:data = Get-TestData
+    $script:refs = Initialize-ReferenceObjects
+
+    $script:UnitTestType = '_unitTestObject'
+    $script:created = [System.Collections.Generic.List[object]]::new()
+
+    function New-XPathTestObject
+    {
+        # Creates and saves a _unitTestObject instance, tracks its ObjectID for AfterAll cleanup,
+        # and returns the saved object. Attributes is a map of attribute system name to value; an
+        # empty map creates a bare object.
+        param([Parameter(Mandatory)] [hashtable] $Attributes)
+
+        $resource = New-Resource -ObjectType $script:UnitTestType
+        foreach ($name in $Attributes.Keys)
+        {
+            $resource.$name = $Attributes[$name]
+        }
+        Save-Resource $resource
+        $script:created.Add($resource.ObjectID)
+        return $resource
+    }
+
+    function Clear-TargetAttribute
+    {
+        # Re-reads an object from the service and explicitly clears one attribute. This mirrors the
+        # refresh/set-null/save dance in XpathPredicateBooleanTests.TestSVBooleanIsNotPresent. The
+        # FIM service stores an omitted single-valued boolean as false at create time even though
+        # the create request carries no value for it (verified against the service's own Request
+        # log), so the only way to make a boolean genuinely absent is to clear it with an update
+        # after creation. Other attribute types remain absent when omitted from a create.
+        param([Parameter(Mandatory)] $Resource, [Parameter(Mandatory)] [string] $Attribute)
+
+        $fresh = Get-Resource -ID $Resource.ObjectID
+        $fresh.$Attribute = $null
+        Save-Resource $fresh
+        return $fresh
+    }
+
+    function Invoke-XPathSearch
+    {
+        # Wraps a query object or group in an expression against _unitTestObject and returns the
+        # search results as an array.
+        param([Parameter(Mandatory)] $QueryObject)
+
+        $expression = New-XPathExpression -ObjectType $script:UnitTestType -QueryObject $QueryObject
+        return @(Search-Resources -XPath $expression)
+    }
+
+    function Assert-OnlyMatches
+    {
+        # Asserts the result set contains exactly the expected objects (by ObjectID), no more and
+        # no fewer.
+        param($Results, [object[]] $Expected)
+
+        $resultIds = @($Results | ForEach-Object { "$($_.ObjectID)" })
+        $expectedIds = @($Expected | ForEach-Object { "$($_.ObjectID)" })
+
+        $resultIds.Count | Should -Be $expectedIds.Count
+        foreach ($id in $expectedIds)
+        {
+            $resultIds | Should -Contain $id
+        }
+    }
+
+    function Test-ScopedPredicate
+    {
+        # Creates a matching and a non-matching object (both carrying the same unique marker),
+        # builds an And group of [marker predicate, predicate under test], searches, and asserts
+        # only the matching object is returned.
+        #
+        # A $null MatchValue/NonMatchValue means the target attribute is left unset on that object
+        # (used by the presence tests). For IsPresent/IsNotPresent no query value is supplied.
+        param(
+            [Parameter(Mandatory)] [string] $MarkerAttr,
+            [Parameter(Mandatory)] [string] $TargetAttr,
+            [Parameter(Mandatory)] [string] $Operator,
+            $QueryValue,
+            $MatchValue,
+            $NonMatchValue,
+            [switch] $Sleep,
+            [switch] $ClearAbsent
+        )
+
+        if ($MarkerAttr -eq 'ut_svinteger')
+        {
+            $markerValue = [long](Get-Random -Minimum 100000000 -Maximum 2000000000)
+        }
+        else
+        {
+            $markerValue = "xpath-$([Guid]::NewGuid().ToString('N'))"
+        }
+
+        $markerQuery = New-XPathQuery -AttributeName $MarkerAttr -Operator Equals -Value $markerValue
+
+        $matchSet = @{}
+        $matchSet[$MarkerAttr] = $markerValue
+        if ($null -ne $MatchValue)
+        {
+            $matchSet[$TargetAttr] = $MatchValue
+        }
+        $match = New-XPathTestObject $matchSet
+
+        $nonSet = @{}
+        $nonSet[$MarkerAttr] = $markerValue
+        if ($null -ne $NonMatchValue)
+        {
+            $nonSet[$TargetAttr] = $NonMatchValue
+        }
+        $nonMatch = New-XPathTestObject $nonSet
+
+        if ($ClearAbsent)
+        {
+            # Single-valued booleans omitted at create time are stored as false by the FIM service,
+            # so presence predicates need the absent-side object explicitly cleared after creation
+            # (see Clear-TargetAttribute).
+            if ($null -eq $MatchValue)
+            {
+                $match = Clear-TargetAttribute -Resource $match -Attribute $TargetAttr
+            }
+            if ($null -eq $NonMatchValue)
+            {
+                $nonMatch = Clear-TargetAttribute -Resource $nonMatch -Attribute $TargetAttr
+            }
+        }
+
+        if ($Operator -eq 'IsPresent' -or $Operator -eq 'IsNotPresent')
+        {
+            $predicate = New-XPathQuery -AttributeName $TargetAttr -Operator $Operator
+        }
+        else
+        {
+            $predicate = New-XPathQuery -AttributeName $TargetAttr -Operator $Operator -Value $QueryValue
+        }
+
+        $scoped = New-XPathQueryGroup -Operator And -Queries $markerQuery, $predicate
+
+        if ($Sleep)
+        {
+            # The MIM full-text index lags creation for the contains() operator; the client unit
+            # tests sleep for the same reason before running a contains query.
+            Start-Sleep -Seconds 10
+        }
+
+        $results = Invoke-XPathSearch $scoped
+        Assert-OnlyMatches -Results $results -Expected @($match)
+    }
+}
+
+AfterAll {
+    foreach ($id in $script:created)
+    {
+        $id | Remove-TestResource
+    }
+}
+
+Describe 'LithnetRMA XPath queries' {
+
+    Context 'String predicates' {
+
+        It 'single-valued string <Name>' -ForEach @(
+            @{ Name = 'equals';                          Op = 'Equals';     Q = 'user0001';  Match = 'user0001';  Non = 'user0002' }
+            @{ Name = 'equals a value with a single quote'; Op = 'Equals';  Q = "user'0001"; Match = "user'0001"; Non = 'user0002' }
+            @{ Name = 'equals a value with a double quote'; Op = 'Equals';  Q = 'user"0001'; Match = 'user"0001'; Non = 'user0002' }
+            @{ Name = 'not equals';                      Op = 'NotEquals';  Q = 'user0001';  Match = 'user0002';  Non = 'user0001' }
+            @{ Name = 'ends with';                       Op = 'EndsWith';   Q = '0001';      Match = 'user0001';  Non = 'user0002' }
+            @{ Name = 'starts with';                     Op = 'StartsWith'; Q = 'y';         Match = 'yuser0001'; Non = 'xuser0002' }
+        ) {
+            Test-ScopedPredicate -MarkerAttr ut_svinteger -TargetAttr ut_svstring -Operator $Op -QueryValue $Q -MatchValue $Match -NonMatchValue $Non
+        }
+
+        It 'single-valued string contains a term after a word break' {
+            Test-ScopedPredicate -MarkerAttr ut_svinteger -TargetAttr ut_svstring -Operator Contains -QueryValue 'abc' -MatchValue 'user abc' -NonMatchValue 'user def' -Sleep
+        }
+
+        It 'single-valued string <Name>' -ForEach @(
+            @{ Name = 'is present';     Op = 'IsPresent';    Side = 'match' }
+            @{ Name = 'is not present'; Op = 'IsNotPresent'; Side = 'non' }
+        ) {
+            $value = 'user0001'
+            if ($Side -eq 'match') { $mv = $value; $nv = $null } else { $mv = $null; $nv = $value }
+            Test-ScopedPredicate -MarkerAttr ut_svinteger -TargetAttr ut_svstring -Operator $Op -MatchValue $mv -NonMatchValue $nv
+        }
+
+        It 'rejects an equals value that contains both single and double quotes' {
+            $predicate = New-XPathQuery -AttributeName ut_svstring -Operator Equals -Value 'user"''0001'
+            {
+                $expression = New-XPathExpression -ObjectType $script:UnitTestType -QueryObject $predicate
+                Search-Resources -XPath $expression | Out-Null
+            } | Should -Throw -ExpectedMessage '*both single and double quotes*'
+        }
+
+        It 'multi-valued string <Name>' -ForEach @(
+            @{ Name = 'equals';      Op = 'Equals';     Q = 'user0001'; Match = @('user0001', 'user0002');  Non = @('user0003', 'user0004') }
+            @{ Name = 'not equals';  Op = 'NotEquals';  Q = 'user0001'; Match = @('user0003', 'user0004');  Non = @('user0001', 'user0002') }
+            @{ Name = 'ends with';   Op = 'EndsWith';   Q = '0001';     Match = @('user0002', 'user0001');  Non = @('user0004', 'user0003') }
+            @{ Name = 'starts with'; Op = 'StartsWith'; Q = 'y';        Match = @('yuser0002', 'yuser0001'); Non = @('xuser0004', 'xuser0003') }
+        ) {
+            Test-ScopedPredicate -MarkerAttr ut_svinteger -TargetAttr ut_mvstring -Operator $Op -QueryValue $Q -MatchValue $Match -NonMatchValue $Non
+        }
+
+        It 'multi-valued string contains a term after a word break' {
+            Test-ScopedPredicate -MarkerAttr ut_svinteger -TargetAttr ut_mvstring -Operator Contains -QueryValue 'abc' -MatchValue @('sdf abc', '1011 ghi') -NonMatchValue @('123 def', '456 def') -Sleep
+        }
+
+        It 'multi-valued string <Name>' -ForEach @(
+            @{ Name = 'is present';     Op = 'IsPresent';    Side = 'match' }
+            @{ Name = 'is not present'; Op = 'IsNotPresent'; Side = 'non' }
+        ) {
+            $value = @('user0001', 'user0002')
+            if ($Side -eq 'match') { $mv = $value; $nv = $null } else { $mv = $null; $nv = $value }
+            Test-ScopedPredicate -MarkerAttr ut_svinteger -TargetAttr ut_mvstring -Operator $Op -MatchValue $mv -NonMatchValue $nv
+        }
+    }
+
+    Context 'Integer predicates' {
+
+        It 'single-valued integer <Name>' -ForEach @(
+            @{ Name = 'equals';                Op = 'Equals';               Q = [long]1;  Match = [long]1;  Non = [long]2 }
+            @{ Name = 'not equals';            Op = 'NotEquals';            Q = [long]1;  Match = [long]2;  Non = [long]1 }
+            @{ Name = 'greater than';          Op = 'GreaterThan';          Q = [long]10; Match = [long]11; Non = [long]5 }
+            @{ Name = 'greater than or equal'; Op = 'GreaterThanOrEquals';  Q = [long]10; Match = [long]10; Non = [long]5 }
+            @{ Name = 'less than';             Op = 'LessThan';             Q = [long]10; Match = [long]9;  Non = [long]15 }
+            @{ Name = 'less than or equal';    Op = 'LessThanOrEquals';     Q = [long]10; Match = [long]10; Non = [long]15 }
+        ) {
+            Test-ScopedPredicate -MarkerAttr ut_svstring -TargetAttr ut_svinteger -Operator $Op -QueryValue $Q -MatchValue $Match -NonMatchValue $Non
+        }
+
+        It 'single-valued integer <Name>' -ForEach @(
+            @{ Name = 'is present';     Op = 'IsPresent';    Side = 'match' }
+            @{ Name = 'is not present'; Op = 'IsNotPresent'; Side = 'non' }
+        ) {
+            $value = [long]1
+            if ($Side -eq 'match') { $mv = $value; $nv = $null } else { $mv = $null; $nv = $value }
+            Test-ScopedPredicate -MarkerAttr ut_svstring -TargetAttr ut_svinteger -Operator $Op -MatchValue $mv -NonMatchValue $nv
+        }
+
+        It 'multi-valued integer <Name>' -ForEach @(
+            @{ Name = 'equals';                Op = 'Equals';              Q = [long]1;  Match = @([long]1, [long]4);  Non = @([long]2, [long]3) }
+            @{ Name = 'not equals';            Op = 'NotEquals';           Q = [long]1;  Match = @([long]3, [long]4);  Non = @([long]1, [long]3) }
+            @{ Name = 'greater than';          Op = 'GreaterThan';         Q = [long]10; Match = @([long]9, [long]11); Non = @([long]9, [long]8) }
+            @{ Name = 'greater than or equal'; Op = 'GreaterThanOrEquals'; Q = [long]10; Match = @([long]9, [long]10); Non = @([long]9, [long]8) }
+            @{ Name = 'less than';             Op = 'LessThan';            Q = [long]10; Match = @([long]9, [long]20); Non = @([long]15, [long]20) }
+            @{ Name = 'less than or equal';    Op = 'LessThanOrEquals';    Q = [long]10; Match = @([long]10, [long]20); Non = @([long]15, [long]20) }
+        ) {
+            Test-ScopedPredicate -MarkerAttr ut_svstring -TargetAttr ut_mvinteger -Operator $Op -QueryValue $Q -MatchValue $Match -NonMatchValue $Non
+        }
+
+        It 'multi-valued integer <Name>' -ForEach @(
+            @{ Name = 'is present';     Op = 'IsPresent';    Side = 'match' }
+            @{ Name = 'is not present'; Op = 'IsNotPresent'; Side = 'non' }
+        ) {
+            $value = @([long]1, [long]2)
+            if ($Side -eq 'match') { $mv = $value; $nv = $null } else { $mv = $null; $nv = $value }
+            Test-ScopedPredicate -MarkerAttr ut_svstring -TargetAttr ut_mvinteger -Operator $Op -MatchValue $mv -NonMatchValue $nv
+        }
+    }
+
+    Context 'Boolean predicates' {
+
+        It 'single-valued boolean <Name>' -ForEach @(
+            @{ Name = 'equals true';     Op = 'Equals';    Q = $true; Match = $true;  Non = $false }
+            @{ Name = 'not equals true'; Op = 'NotEquals'; Q = $true; Match = $false; Non = $true }
+        ) {
+            Test-ScopedPredicate -MarkerAttr ut_svstring -TargetAttr ut_svboolean -Operator $Op -QueryValue $Q -MatchValue $Match -NonMatchValue $Non
+        }
+
+        It 'single-valued boolean <Name>' -ForEach @(
+            @{ Name = 'is present';     Op = 'IsPresent';    Side = 'match' }
+            @{ Name = 'is not present'; Op = 'IsNotPresent'; Side = 'non' }
+        ) {
+            # Ports TestSVBooleanIsPresent/IsNotPresent. The NUnit suite tolerates a created-unset
+            # boolean matching a presence query because its result-count assertion is commented out;
+            # this suite asserts exact result sets, so the absent-side object is explicitly cleared
+            # after creation — the same dance TestSVBooleanIsNotPresent performs on its match object.
+            $value = $true
+            if ($Side -eq 'match') { $mv = $value; $nv = $null } else { $mv = $null; $nv = $value }
+            Test-ScopedPredicate -MarkerAttr ut_svstring -TargetAttr ut_svboolean -Operator $Op -MatchValue $mv -NonMatchValue $nv -ClearAbsent
+        }
+    }
+
+    Context 'DateTime predicates' {
+
+        It 'single-valued datetime <Name>' -ForEach @(
+            @{ Name = 'equals';                                  Op = 'Equals';              Q = '2000-01-01T00:00:00.000'; Match = '2000-01-01T00:00:00.000'; Non = '3000-01-01T00:00:00.000' }
+            @{ Name = 'not equals';                              Op = 'NotEquals';           Q = '2000-01-01T00:00:00.000'; Match = '3000-01-01T00:00:00.000'; Non = '2000-01-01T00:00:00.000' }
+            @{ Name = 'greater than';                            Op = 'GreaterThan';         Q = '3000-01-01T00:00:00.000'; Match = '3100-01-01T00:00:00.000'; Non = '2000-01-01T00:00:00.000' }
+            @{ Name = 'greater than a function value';           Op = 'GreaterThan';         Q = 'current-dateTime()';      Match = '3000-01-01T00:00:00.000'; Non = '2000-01-01T00:00:00.000' }
+            @{ Name = 'greater than or equal';                   Op = 'GreaterThanOrEquals'; Q = '3000-01-01T00:00:00.000'; Match = '3000-01-01T00:00:00.000'; Non = '2000-01-01T00:00:00.000' }
+            @{ Name = 'greater than or equal to a function value'; Op = 'GreaterThanOrEquals'; Q = 'current-dateTime()';    Match = '3000-01-01T00:00:00.000'; Non = '2000-01-01T00:00:00.000' }
+            @{ Name = 'less than';                               Op = 'LessThan';            Q = '2000-01-01T00:00:00.000'; Match = '1900-01-01T00:00:00.000'; Non = '2100-01-01T00:00:00.000' }
+            @{ Name = 'less than a function value';              Op = 'LessThan';            Q = 'current-dateTime()';      Match = '2000-01-01T00:00:00.000'; Non = '3000-01-01T00:00:00.000' }
+            @{ Name = 'less than or equal';                      Op = 'LessThanOrEquals';    Q = '2000-01-01T00:00:00.000'; Match = '2000-01-01T00:00:00.000'; Non = '2100-01-01T00:00:00.000' }
+            @{ Name = 'less than or equal to a function value';  Op = 'LessThanOrEquals';    Q = 'current-dateTime()';      Match = '2000-01-01T00:00:00.000'; Non = '3000-01-01T00:00:00.000' }
+        ) {
+            Test-ScopedPredicate -MarkerAttr ut_svstring -TargetAttr ut_svdatetime -Operator $Op -QueryValue $Q -MatchValue $Match -NonMatchValue $Non
+        }
+
+        It 'single-valued datetime <Name>' -ForEach @(
+            @{ Name = 'is present';     Op = 'IsPresent';    Side = 'match' }
+            @{ Name = 'is not present'; Op = 'IsNotPresent'; Side = 'non' }
+        ) {
+            $value = '2000-01-01T00:00:00.000'
+            if ($Side -eq 'match') { $mv = $value; $nv = $null } else { $mv = $null; $nv = $value }
+            Test-ScopedPredicate -MarkerAttr ut_svstring -TargetAttr ut_svdatetime -Operator $Op -MatchValue $mv -NonMatchValue $nv
+        }
+
+        It 'multi-valued datetime <Name>' -ForEach @(
+            @{ Name = 'equals';                                  Op = 'Equals';              Q = '2000-01-01T00:00:00.000'; Match = @('2300-01-01T00:00:00.000', '2000-01-01T00:00:00.000'); Non = @('2100-01-01T00:00:00.000', '2200-01-01T00:00:00.000') }
+            @{ Name = 'not equals';                              Op = 'NotEquals';           Q = '2000-01-01T00:00:00.000'; Match = @('2200-01-01T00:00:00.000', '2300-01-01T00:00:00.000'); Non = @('2000-01-01T00:00:00.000', '2100-01-01T00:00:00.000') }
+            @{ Name = 'greater than';                            Op = 'GreaterThan';         Q = '2000-01-01T00:00:00.000'; Match = @('2100-01-01T00:00:00.000', '2200-01-01T00:00:00.000'); Non = @('1900-01-01T00:00:00.000', '1800-01-01T00:00:00.000') }
+            @{ Name = 'greater than a function value';           Op = 'GreaterThan';         Q = 'current-dateTime()';      Match = @('2100-01-01T00:00:00.000', '2200-01-01T00:00:00.000'); Non = @('1900-01-01T00:00:00.000', '1800-01-01T00:00:00.000') }
+            @{ Name = 'greater than or equal';                   Op = 'GreaterThanOrEquals'; Q = '2000-01-01T00:00:00.000'; Match = @('2000-01-01T00:00:00.000', '2100-01-01T00:00:00.000'); Non = @('1900-01-01T00:00:00.000', '1800-01-01T00:00:00.000') }
+            @{ Name = 'greater than or equal to a function value'; Op = 'GreaterThanOrEquals'; Q = 'current-dateTime()';    Match = @('2000-01-01T00:00:00.000', '2100-01-01T00:00:00.000'); Non = @('1900-01-01T00:00:00.000', '1800-01-01T00:00:00.000') }
+            @{ Name = 'less than';                               Op = 'LessThan';            Q = '2000-01-01T00:00:00.000'; Match = @('1900-01-01T00:00:00.000', '1800-01-01T00:00:00.000'); Non = @('2100-01-01T00:00:00.000', '2200-01-01T00:00:00.000') }
+            @{ Name = 'less than a function value';              Op = 'LessThan';            Q = 'current-dateTime()';      Match = @('1900-01-01T00:00:00.000', '1800-01-01T00:00:00.000'); Non = @('2100-01-01T00:00:00.000', '2200-01-01T00:00:00.000') }
+            @{ Name = 'less than or equal';                      Op = 'LessThanOrEquals';    Q = '2000-01-01T00:00:00.000'; Match = @('2000-01-01T00:00:00.000', '2200-01-01T00:00:00.000'); Non = @('2100-01-01T00:00:00.000', '2200-01-01T00:00:00.000') }
+            @{ Name = 'less than or equal to a function value';  Op = 'LessThanOrEquals';    Q = 'current-dateTime()';      Match = @('2000-01-01T00:00:00.000', '2200-01-01T00:00:00.000'); Non = @('2100-01-01T00:00:00.000', '2200-01-01T00:00:00.000') }
+        ) {
+            Test-ScopedPredicate -MarkerAttr ut_svstring -TargetAttr ut_mvdatetime -Operator $Op -QueryValue $Q -MatchValue $Match -NonMatchValue $Non
+        }
+
+        It 'multi-valued datetime <Name>' -ForEach @(
+            @{ Name = 'is present';     Op = 'IsPresent';    Side = 'match' }
+            @{ Name = 'is not present'; Op = 'IsNotPresent'; Side = 'non' }
+        ) {
+            $value = @('2000-01-01T00:00:00.000', '2100-01-01T00:00:00.000')
+            if ($Side -eq 'match') { $mv = $value; $nv = $null } else { $mv = $null; $nv = $value }
+            Test-ScopedPredicate -MarkerAttr ut_svstring -TargetAttr ut_mvdatetime -Operator $Op -MatchValue $mv -NonMatchValue $nv
+        }
+    }
+
+    Context 'Reference predicates' {
+
+        It 'single-valued reference equals the query value' {
+            Test-ScopedPredicate -MarkerAttr ut_svstring -TargetAttr ut_svreference -Operator Equals -QueryValue $script:refs.Ref1 -MatchValue $script:refs.Ref1 -NonMatchValue $script:refs.Ref2
+        }
+
+        It 'single-valued reference not equals the query value' {
+            Test-ScopedPredicate -MarkerAttr ut_svstring -TargetAttr ut_svreference -Operator NotEquals -QueryValue $script:refs.Ref1 -MatchValue $script:refs.Ref2 -NonMatchValue $script:refs.Ref1
+        }
+
+        It 'single-valued reference is present' {
+            Test-ScopedPredicate -MarkerAttr ut_svstring -TargetAttr ut_svreference -Operator IsPresent -MatchValue $script:refs.Ref1 -NonMatchValue $null
+        }
+
+        It 'single-valued reference is not present' {
+            Test-ScopedPredicate -MarkerAttr ut_svstring -TargetAttr ut_svreference -Operator IsNotPresent -MatchValue $null -NonMatchValue $script:refs.Ref1
+        }
+
+        It 'multi-valued reference equals the query value' {
+            Test-ScopedPredicate -MarkerAttr ut_svstring -TargetAttr ut_mvreference -Operator Equals -QueryValue $script:refs.Ref1 -MatchValue $script:refs.Ref1MV -NonMatchValue $script:refs.Ref2MV
+        }
+
+        It 'multi-valued reference not equals the query value' {
+            Test-ScopedPredicate -MarkerAttr ut_svstring -TargetAttr ut_mvreference -Operator NotEquals -QueryValue $script:refs.Ref1 -MatchValue $script:refs.Ref2MV -NonMatchValue $script:refs.Ref1MV
+        }
+
+        It 'multi-valued reference is present' {
+            Test-ScopedPredicate -MarkerAttr ut_svstring -TargetAttr ut_mvreference -Operator IsPresent -MatchValue $script:refs.Ref1MV -NonMatchValue $null
+        }
+
+        It 'multi-valued reference is not present' {
+            Test-ScopedPredicate -MarkerAttr ut_svstring -TargetAttr ut_mvreference -Operator IsNotPresent -MatchValue $null -NonMatchValue $script:refs.Ref1MV
+        }
+    }
+
+    Context 'Query groups' {
+
+        It 'returns matches for a group containing a single predicate' {
+            $marker = "xpath-$([Guid]::NewGuid().ToString('N'))"
+            $match = New-XPathTestObject @{ ut_svstring = $marker }
+            $nonMatch = New-XPathTestObject @{ ut_svstring = "xpath-$([Guid]::NewGuid().ToString('N'))" }
+
+            $group = New-XPathQueryGroup -Operator And -Queries (New-XPathQuery -AttributeName ut_svstring -Operator Equals -Value $marker)
+
+            $results = Invoke-XPathSearch $group
+            Assert-OnlyMatches -Results $results -Expected @($match)
+        }
+
+        It 'returns only objects satisfying every predicate in an And group' {
+            $marker = "xpath-$([Guid]::NewGuid().ToString('N'))"
+            $match = New-XPathTestObject @{ ut_svstring = $marker; ut_svinteger = [long]100 }
+            $wrongInteger = New-XPathTestObject @{ ut_svstring = $marker; ut_svinteger = [long]999 }
+            $wrongMarker = New-XPathTestObject @{ ut_svstring = "xpath-$([Guid]::NewGuid().ToString('N'))"; ut_svinteger = [long]100 }
+
+            $markerQuery = New-XPathQuery -AttributeName ut_svstring -Operator Equals -Value $marker
+            $integerQuery = New-XPathQuery -AttributeName ut_svinteger -Operator Equals -Value ([long]100)
+            $group = New-XPathQueryGroup -Operator And -Queries $markerQuery, $integerQuery
+
+            $results = Invoke-XPathSearch $group
+            Assert-OnlyMatches -Results $results -Expected @($match)
+        }
+
+        It 'returns objects satisfying any predicate in an Or group' {
+            $marker = "xpath-$([Guid]::NewGuid().ToString('N'))"
+            $matchInteger = New-XPathTestObject @{ ut_svstring = $marker; ut_svinteger = [long]200 }
+            $matchString = New-XPathTestObject @{ ut_svstring = $marker; ut_mvstring = @('grpor term', 'other') }
+            $neither = New-XPathTestObject @{ ut_svstring = $marker; ut_svinteger = [long]1 }
+
+            $markerQuery = New-XPathQuery -AttributeName ut_svstring -Operator Equals -Value $marker
+            $orInteger = New-XPathQuery -AttributeName ut_svinteger -Operator Equals -Value ([long]200)
+            $orString = New-XPathQuery -AttributeName ut_mvstring -Operator Equals -Value 'grpor term'
+            $orGroup = New-XPathQueryGroup -Operator Or -Queries $orInteger, $orString
+            $group = New-XPathQueryGroup -Operator And -Queries $markerQuery, $orGroup
+
+            $results = Invoke-XPathSearch $group
+            Assert-OnlyMatches -Results $results -Expected @($matchInteger, $matchString)
+        }
+
+        It 'evaluates a nested group (an And of a predicate and an Or group)' {
+            $marker = "xpath-$([Guid]::NewGuid().ToString('N'))"
+            $match = New-XPathTestObject @{ ut_svstring = $marker; ut_svinteger = [long]55; ut_mvstring = @('nested term', 'x') }
+            $wrongInteger = New-XPathTestObject @{ ut_svstring = $marker; ut_svinteger = [long]56; ut_mvstring = @('nested term') }
+            $wrongOr = New-XPathTestObject @{ ut_svstring = $marker; ut_svinteger = [long]55; ut_mvstring = @('no term') }
+
+            $markerQuery = New-XPathQuery -AttributeName ut_svstring -Operator Equals -Value $marker
+            $integerQuery = New-XPathQuery -AttributeName ut_svinteger -Operator Equals -Value ([long]55)
+            $orString = New-XPathQuery -AttributeName ut_mvstring -Operator Equals -Value 'nested term'
+            $orBoolean = New-XPathQuery -AttributeName ut_svboolean -Operator Equals -Value $true
+            $childOrGroup = New-XPathQueryGroup -Operator Or -Queries $orString, $orBoolean
+            $group = New-XPathQueryGroup -Operator And -Queries $markerQuery, $integerQuery, $childOrGroup
+
+            $results = Invoke-XPathSearch $group
+            Assert-OnlyMatches -Results $results -Expected @($match)
+        }
+    }
+
+    Context 'Expression building' {
+
+        It 'resolves a reference predicate whose value is a child expression' {
+            $marker = "xpath-$([Guid]::NewGuid().ToString('N'))"
+            $filterTarget = New-XPathTestObject @{ ut_svstring = $marker }
+            $children = 1..3 | ForEach-Object {
+                New-XPathTestObject @{ ut_svreference = $filterTarget.ObjectID }
+            }
+
+            $childExpression = New-XPathExpression -ObjectType $script:UnitTestType -QueryObject (
+                New-XPathQuery -AttributeName ut_svstring -Operator Equals -Value $marker)
+            $referencePredicate = New-XPathQuery -AttributeName ut_svreference -Operator Equals -Value $childExpression
+            $outerExpression = New-XPathExpression -ObjectType $script:UnitTestType -QueryObject $referencePredicate
+
+            $results = @(Search-Resources -XPath $outerExpression)
+            Assert-OnlyMatches -Results $results -Expected $children
+        }
+
+        It 'dereferences a reference attribute to return the parent objects' {
+            $marker = "xpath-$([Guid]::NewGuid().ToString('N'))"
+            $parent = New-XPathTestObject @{}
+            $filterTarget = New-XPathTestObject @{ ut_svstring = $marker; ut_svreference = $parent.ObjectID }
+
+            $expression = New-XPathExpression -ObjectType $script:UnitTestType -DereferenceAttribute ut_svreference -QueryObject (
+                New-XPathQuery -AttributeName ut_svstring -Operator Equals -Value $marker)
+
+            $results = @(Search-Resources -XPath $expression)
+            Assert-OnlyMatches -Results $results -Expected @($parent)
+        }
+    }
+
+    Context 'Unsupported operator and type combinations' {
+
+        It 'rejects <Op> on <Attr>' -ForEach @(
+            @{ Attr = 'ut_svstring';    Op = 'GreaterThan' }
+            @{ Attr = 'ut_svstring';    Op = 'GreaterThanOrEquals' }
+            @{ Attr = 'ut_svstring';    Op = 'LessThan' }
+            @{ Attr = 'ut_svstring';    Op = 'LessThanOrEquals' }
+            @{ Attr = 'ut_svinteger';   Op = 'Contains' }
+            @{ Attr = 'ut_svinteger';   Op = 'StartsWith' }
+            @{ Attr = 'ut_svinteger';   Op = 'EndsWith' }
+            @{ Attr = 'ut_mvinteger';   Op = 'Contains' }
+            @{ Attr = 'ut_mvinteger';   Op = 'StartsWith' }
+            @{ Attr = 'ut_mvinteger';   Op = 'EndsWith' }
+            @{ Attr = 'ut_svdatetime';  Op = 'Contains' }
+            @{ Attr = 'ut_svdatetime';  Op = 'StartsWith' }
+            @{ Attr = 'ut_svdatetime';  Op = 'EndsWith' }
+            @{ Attr = 'ut_mvdatetime';  Op = 'Contains' }
+            @{ Attr = 'ut_mvdatetime';  Op = 'StartsWith' }
+            @{ Attr = 'ut_mvdatetime';  Op = 'EndsWith' }
+            @{ Attr = 'ut_svboolean';   Op = 'GreaterThan' }
+            @{ Attr = 'ut_svboolean';   Op = 'GreaterThanOrEquals' }
+            @{ Attr = 'ut_svboolean';   Op = 'LessThan' }
+            @{ Attr = 'ut_svboolean';   Op = 'LessThanOrEquals' }
+            @{ Attr = 'ut_svboolean';   Op = 'Contains' }
+            @{ Attr = 'ut_svboolean';   Op = 'StartsWith' }
+            @{ Attr = 'ut_svboolean';   Op = 'EndsWith' }
+            @{ Attr = 'ut_svreference'; Op = 'GreaterThan' }
+            @{ Attr = 'ut_svreference'; Op = 'GreaterThanOrEquals' }
+            @{ Attr = 'ut_svreference'; Op = 'LessThan' }
+            @{ Attr = 'ut_svreference'; Op = 'LessThanOrEquals' }
+            @{ Attr = 'ut_svreference'; Op = 'Contains' }
+            @{ Attr = 'ut_svreference'; Op = 'StartsWith' }
+            @{ Attr = 'ut_svreference'; Op = 'EndsWith' }
+            @{ Attr = 'ut_mvreference'; Op = 'GreaterThan' }
+            @{ Attr = 'ut_mvreference'; Op = 'GreaterThanOrEquals' }
+            @{ Attr = 'ut_mvreference'; Op = 'LessThan' }
+            @{ Attr = 'ut_mvreference'; Op = 'LessThanOrEquals' }
+            @{ Attr = 'ut_mvreference'; Op = 'Contains' }
+            @{ Attr = 'ut_mvreference'; Op = 'StartsWith' }
+            @{ Attr = 'ut_mvreference'; Op = 'EndsWith' }
+        ) {
+            { New-XPathQuery -AttributeName $Attr -Operator $Op -Value 'x' } | Should -Throw
+        }
+    }
+}

--- a/test/LithnetRMA.Tests/_Bootstrap.ps1
+++ b/test/LithnetRMA.Tests/_Bootstrap.ps1
@@ -1,0 +1,27 @@
+<#
+    Shared setup for the LithnetRMA Pester suite. Dot-sourced from each *.Tests.ps1 BeforeAll.
+
+    Imports the module staged by Invoke-Tests.ps1 (Build-TestModule.ps1 output) and connects to the
+    test MIM service. The endpoint mirrors the resourcemanagement-client unit tests: the 'fimsvc'
+    alias, SPN 'FIMService/fimsvc'. LocalProxy is the default connection mode because it matches the
+    unit tests and does not depend on the RemoteProxy service address resolution. All values are
+    overridable by environment variable so the same suite runs in CI against a different lab.
+#>
+$ErrorActionPreference = 'Stop'
+
+if (-not $env:LITHNETRMA_MODULE_PATH)
+{
+    throw 'LITHNETRMA_MODULE_PATH is not set. Run the suite via Invoke-Tests.ps1, which builds and stages the module first.'
+}
+
+# Ensure a version installed on the machine (e.g. from PSGallery) cannot shadow the source build.
+Get-Module LithnetRMA | Remove-Module -Force
+Import-Module $env:LITHNETRMA_MODULE_PATH -Force
+
+Import-Module (Join-Path $PSScriptRoot 'LithnetRMA.TestSupport.psm1') -Force
+
+Connect-TestClient
+
+# Once-per-process suite setup: ensure the _unitTestObject schema exists and start from a clean slate
+# (delete all leftover test objects), mirroring the unit tests' Setup.cs / DeleteAllTestObjects.
+Initialize-TestEnvironment


### PR DESCRIPTION
Fixes #45.

- Cmdlets declared [object]/[object[]] parameters and then hard-cast to client types or type-tested with as. PowerShell wraps values passed to object parameters in a PSObject, so hard casts threw InvalidCastException and as tests silently missed (wrapped IDs were dropped, turning operations into silent no-ops). Parameters now declare real types or unwrap via a PSObject argument transformation, covering the reported cmdlets and the latent ones with the same defect.
- A Pester suite mirroring the client unit tests now gates every release against the lab MIM service, on both PowerShell editions and across every transport (Windows PowerShell 5.1 with DirectWsHttp; PowerShell 7 with LocalProxy, RemoteProxy, and DirectNetTcp). Approval scenarios are mandatory gate coverage and fail the gate loudly when their preconditions are missing.
